### PR TITLE
finished conection to maps app

### DIFF
--- a/wheels/lib/features/rides/presentation/screens/active_ride_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/active_ride_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../features/auth/presentation/providers/auth_providers.dart';
 import '../../../../router/app_routes.dart';
+import '../../../../shared/services/navigation_launcher_service.dart';
 import '../../../../shared/ui/app_scaffold.dart';
 import '../../../../shared/widgets/app_bottom_nav.dart';
 import '../../../../theme/app_colors.dart';
@@ -16,6 +17,8 @@ import '../providers/rides_providers.dart';
 
 class ActiveRideScreen extends ConsumerWidget {
   const ActiveRideScreen({this.rideId, super.key});
+
+  static const _navigationLauncher = NavigationLauncherService();
 
   final String? rideId;
 
@@ -214,6 +217,26 @@ class ActiveRideScreen extends ConsumerWidget {
     required List<RideApplicationEntity> applications,
     required bool isLoading,
   }) {
+    Future<void> openNavigation() async {
+      final opened = await _navigationLauncher.openDrivingDirections(
+        destination: ride.destination,
+      );
+
+      if (!context.mounted) {
+        return;
+      }
+
+      if (!opened) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            const SnackBar(
+              content: Text('We could not open Google Maps for this route.'),
+            ),
+          );
+      }
+    }
+
     Future<void> updateStatus(String status, String successMessage) async {
       await ref
           .read(rideStatusControllerProvider.notifier)
@@ -227,6 +250,14 @@ class ActiveRideScreen extends ConsumerWidget {
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
         ..showSnackBar(SnackBar(content: Text(successMessage)));
+
+      if (status == 'in_progress') {
+        await openNavigation();
+      }
+
+      if (!context.mounted) {
+        return;
+      }
 
       if (status == 'cancelled' || status == 'completed') {
         context.go(AppRoutes.dashboard);
@@ -266,6 +297,21 @@ class ActiveRideScreen extends ConsumerWidget {
             child: Text(isLoading ? 'Updating...' : 'Start Ride'),
           ),
         if (ride.status == 'in_progress') ...[
+          const SizedBox(height: AppSpacing.s),
+          ElevatedButton.icon(
+            onPressed: isLoading ? null : openNavigation,
+            icon: const Icon(Icons.navigation_outlined),
+            label: const Text('Open Navigation'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF5B89C8),
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppRadius.md),
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
           OutlinedButton.icon(
             onPressed: isLoading
                 ? null

--- a/wheels/lib/shared/services/navigation_launcher_service.dart
+++ b/wheels/lib/shared/services/navigation_launcher_service.dart
@@ -1,0 +1,36 @@
+import 'package:url_launcher/url_launcher.dart';
+
+class NavigationLauncherService {
+  const NavigationLauncherService();
+
+  Future<bool> openDrivingDirections({
+    required String destination,
+    String? origin,
+  }) async {
+    final cleanedDestination = destination.trim();
+    if (cleanedDestination.isEmpty) {
+      return false;
+    }
+
+    final queryParameters = <String, String>{
+      'api': '1',
+      'destination': cleanedDestination,
+      'travelmode': 'driving',
+      'utm_source': 'Wheels',
+      'utm_campaign': 'ride_navigation',
+    };
+
+    final cleanedOrigin = origin?.trim();
+    if (cleanedOrigin != null && cleanedOrigin.isNotEmpty) {
+      queryParameters['origin'] = cleanedOrigin;
+    }
+
+    final uri = Uri.https(
+      'www.google.com',
+      '/maps/dir/',
+      queryParameters,
+    );
+
+    return launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+}


### PR DESCRIPTION
This PR adds navigation support for drivers when a ride begins. When the driver presses Start Ride, the app updates the ride status to in_progress and then redirects the user to Google Maps with driving directions to the ride destination.


**What changed**

- Added a navigation launcher service to open Google Maps from the app
- Connected the Start Ride action to external navigation
- Added an Open Navigation button while the ride is in progress so the driver can reopen directions at any time
- Kept the existing ride lifecycle flow intact (open -> in_progress -> completed)


**Why this is useful**

This improves the driver experience by reducing friction at the start of a trip. Instead of manually copying the destination into a maps app, the app sends the driver directly to navigation with one tap.


**Implementation notes**

Uses url_launcher
Opens Google Maps through a Maps URL in external application mode
Navigates to the ride destination using driving mode
If navigation cannot be opened, the app shows a snackbar instead of failing silently