### PR TITLE
Feature: Persist recent search filters and results locally

### DIFF
--- a/wheels/lib/features/rides/data/datasources/rides_search_local_datasource.dart
+++ b/wheels/lib/features/rides/data/datasources/rides_search_local_datasource.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/local_ride_search_cache_model.dart';
+
+class RidesSearchLocalDataSource {
+  static const String _cacheKey = 'rides_search_cache_v1';
+
+  Future<LocalRideSearchCacheModel?> loadLatestSearch() async {
+    final prefs = await SharedPreferences.getInstance();
+    final rawCache = prefs.getString(_cacheKey);
+    if (rawCache == null || rawCache.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      final decoded = jsonDecode(rawCache);
+      if (decoded is! Map) {
+        throw const FormatException('Stored rides search cache is invalid.');
+      }
+
+      return LocalRideSearchCacheModel.fromJson(
+        Map<String, dynamic>.from(decoded),
+      );
+    } catch (_) {
+      await clearLatestSearch();
+      return null;
+    }
+  }
+
+  Future<void> saveLatestSearch(LocalRideSearchCacheModel cache) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_cacheKey, jsonEncode(cache.toJson()));
+  }
+
+  Future<void> clearLatestSearch() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_cacheKey);
+  }
+}

--- a/wheels/lib/features/rides/data/models/local_ride_search_cache_model.dart
+++ b/wheels/lib/features/rides/data/models/local_ride_search_cache_model.dart
@@ -1,0 +1,366 @@
+import '../../domain/entities/rides_entity.dart';
+import '../../presentation/models/ride_listing.dart';
+
+class LocalRideSearchFiltersModel {
+  const LocalRideSearchFiltersModel({
+    required this.originQuery,
+    required this.destinationQuery,
+    required this.selectedDate,
+    required this.sort,
+  });
+
+  final String originQuery;
+  final String destinationQuery;
+  final DateTime selectedDate;
+  final RideSortOption sort;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'originQuery': originQuery,
+      'destinationQuery': destinationQuery,
+      'selectedDate': _formatDateOnly(selectedDate),
+      'sort': sort.name,
+    };
+  }
+
+  factory LocalRideSearchFiltersModel.fromJson(Map<String, dynamic> json) {
+    final selectedDate = _parseRequiredDateOnly(
+      json['selectedDate'],
+      fieldName: 'selectedDate',
+    );
+
+    return LocalRideSearchFiltersModel(
+      originQuery: _readRequiredString(json['originQuery'], 'originQuery'),
+      destinationQuery: _readRequiredString(
+        json['destinationQuery'],
+        'destinationQuery',
+      ),
+      selectedDate: selectedDate,
+      sort: _parseSort(json['sort']),
+    );
+  }
+
+  static String _formatDateOnly(DateTime value) {
+    final normalized = DateTime(value.year, value.month, value.day);
+    final month = normalized.month.toString().padLeft(2, '0');
+    final day = normalized.day.toString().padLeft(2, '0');
+    return '${normalized.year}-$month-$day';
+  }
+
+  static DateTime _parseRequiredDateOnly(
+    Object? rawValue, {
+    required String fieldName,
+  }) {
+    final parsed = DateTime.tryParse(_readRequiredString(rawValue, fieldName));
+    if (parsed == null) {
+      throw FormatException('Invalid $fieldName value.');
+    }
+
+    return DateTime(parsed.year, parsed.month, parsed.day);
+  }
+
+  static RideSortOption _parseSort(Object? rawValue) {
+    final rawName = _readRequiredString(rawValue, 'sort');
+    return RideSortOption.values.firstWhere(
+      (value) => value.name == rawName,
+      orElse: () => throw const FormatException('Invalid sort value.'),
+    );
+  }
+}
+
+class LocalRideSearchResultModel {
+  const LocalRideSearchResultModel({
+    required this.id,
+    required this.driverId,
+    required this.driverName,
+    required this.driverEmail,
+    required this.origin,
+    required this.destination,
+    required this.departureAt,
+    required this.estimatedDurationMinutes,
+    required this.totalSeats,
+    required this.availableSeats,
+    required this.pricePerSeat,
+    required this.paymentOption,
+    required this.status,
+    required this.notes,
+    required this.passengerIds,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.driverRating,
+    required this.reviewCount,
+    required this.onTimeRate,
+    required this.verifiedByUniversity,
+  });
+
+  final String id;
+  final String driverId;
+  final String driverName;
+  final String driverEmail;
+  final String origin;
+  final String destination;
+  final DateTime departureAt;
+  final int estimatedDurationMinutes;
+  final int totalSeats;
+  final int availableSeats;
+  final int pricePerSeat;
+  final RidePaymentOption paymentOption;
+  final String status;
+  final String notes;
+  final List<String> passengerIds;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final double driverRating;
+  final int reviewCount;
+  final int onTimeRate;
+  final bool verifiedByUniversity;
+
+  factory LocalRideSearchResultModel.fromEntity(RidesEntity entity) {
+    return LocalRideSearchResultModel(
+      id: entity.id,
+      driverId: entity.driverId,
+      driverName: entity.driverName,
+      driverEmail: entity.driverEmail,
+      origin: entity.origin,
+      destination: entity.destination,
+      departureAt: entity.departureAt,
+      estimatedDurationMinutes: entity.estimatedDurationMinutes,
+      totalSeats: entity.totalSeats,
+      availableSeats: entity.availableSeats,
+      pricePerSeat: entity.pricePerSeat,
+      paymentOption: entity.paymentOption,
+      status: entity.status,
+      notes: entity.notes,
+      passengerIds: List<String>.from(entity.passengerIds),
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      driverRating: entity.driverRating,
+      reviewCount: entity.reviewCount,
+      onTimeRate: entity.onTimeRate,
+      verifiedByUniversity: entity.verifiedByUniversity,
+    );
+  }
+
+  factory LocalRideSearchResultModel.fromJson(Map<String, dynamic> json) {
+    return LocalRideSearchResultModel(
+      id: _readRequiredString(json['id'], 'id'),
+      driverId: _readRequiredString(json['driverId'], 'driverId'),
+      driverName: _readRequiredString(json['driverName'], 'driverName'),
+      driverEmail: _readRequiredString(json['driverEmail'], 'driverEmail'),
+      origin: _readRequiredString(json['origin'], 'origin'),
+      destination: _readRequiredString(json['destination'], 'destination'),
+      departureAt: _parseRequiredDateTime(json['departureAt'], 'departureAt'),
+      estimatedDurationMinutes: _readRequiredInt(
+        json['estimatedDurationMinutes'],
+        'estimatedDurationMinutes',
+      ),
+      totalSeats: _readRequiredInt(json['totalSeats'], 'totalSeats'),
+      availableSeats: _readRequiredInt(
+        json['availableSeats'],
+        'availableSeats',
+      ),
+      pricePerSeat: _readRequiredInt(json['pricePerSeat'], 'pricePerSeat'),
+      paymentOption: ridePaymentOptionFromStorage(
+        _readRequiredString(json['paymentOption'], 'paymentOption'),
+      ),
+      status: _readRequiredString(json['status'], 'status'),
+      notes: _readRequiredString(json['notes'], 'notes'),
+      passengerIds: _readRequiredStringList(
+        json['passengerIds'],
+        'passengerIds',
+      ),
+      createdAt: _parseRequiredDateTime(json['createdAt'], 'createdAt'),
+      updatedAt: _parseRequiredDateTime(json['updatedAt'], 'updatedAt'),
+      driverRating: _readRequiredDouble(json['driverRating'], 'driverRating'),
+      reviewCount: _readRequiredInt(json['reviewCount'], 'reviewCount'),
+      onTimeRate: _readRequiredInt(json['onTimeRate'], 'onTimeRate'),
+      verifiedByUniversity: _readRequiredBool(
+        json['verifiedByUniversity'],
+        'verifiedByUniversity',
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'driverId': driverId,
+      'driverName': driverName,
+      'driverEmail': driverEmail,
+      'origin': origin,
+      'destination': destination,
+      'departureAt': departureAt.toIso8601String(),
+      'estimatedDurationMinutes': estimatedDurationMinutes,
+      'totalSeats': totalSeats,
+      'availableSeats': availableSeats,
+      'pricePerSeat': pricePerSeat,
+      'paymentOption': paymentOption.storageValue,
+      'status': status,
+      'notes': notes,
+      'passengerIds': passengerIds,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
+      'driverRating': driverRating,
+      'reviewCount': reviewCount,
+      'onTimeRate': onTimeRate,
+      'verifiedByUniversity': verifiedByUniversity,
+    };
+  }
+
+  RidesEntity toEntity() {
+    return RidesEntity(
+      id: id,
+      driverId: driverId,
+      driverName: driverName,
+      driverEmail: driverEmail,
+      origin: origin,
+      destination: destination,
+      departureAt: departureAt,
+      estimatedDurationMinutes: estimatedDurationMinutes,
+      totalSeats: totalSeats,
+      availableSeats: availableSeats,
+      pricePerSeat: pricePerSeat,
+      paymentOption: paymentOption,
+      status: status,
+      notes: notes,
+      passengerIds: passengerIds,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      driverRating: driverRating,
+      reviewCount: reviewCount,
+      onTimeRate: onTimeRate,
+      verifiedByUniversity: verifiedByUniversity,
+    );
+  }
+}
+
+class LocalRideSearchCacheModel {
+  const LocalRideSearchCacheModel({
+    required this.version,
+    required this.savedAt,
+    required this.filters,
+    required this.results,
+  });
+
+  static const int currentVersion = 1;
+
+  final int version;
+  final DateTime savedAt;
+  final LocalRideSearchFiltersModel filters;
+  final List<LocalRideSearchResultModel> results;
+
+  factory LocalRideSearchCacheModel.create({
+    required LocalRideSearchFiltersModel filters,
+    required List<RidesEntity> results,
+  }) {
+    return LocalRideSearchCacheModel(
+      version: currentVersion,
+      savedAt: DateTime.now().toUtc(),
+      filters: filters,
+      results: results.map(LocalRideSearchResultModel.fromEntity).toList(),
+    );
+  }
+
+  factory LocalRideSearchCacheModel.fromJson(Map<String, dynamic> json) {
+    final version = _readRequiredInt(json['version'], 'version');
+    if (version != currentVersion) {
+      throw FormatException('Unsupported cache version: $version');
+    }
+
+    final rawResults = json['results'];
+    if (rawResults is! List) {
+      throw const FormatException('Invalid results payload.');
+    }
+
+    return LocalRideSearchCacheModel(
+      version: version,
+      savedAt: _parseRequiredDateTime(json['savedAt'], 'savedAt'),
+      filters: LocalRideSearchFiltersModel.fromJson(
+        Map<String, dynamic>.from(
+          json['filters'] as Map<Object?, Object?>? ??
+              (throw const FormatException('Missing filters payload.')),
+        ),
+      ),
+      results: rawResults
+          .map((item) {
+            if (item is! Map) {
+              throw const FormatException('Invalid ride result item.');
+            }
+            return LocalRideSearchResultModel.fromJson(
+              Map<String, dynamic>.from(item),
+            );
+          })
+          .toList(growable: false),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'version': version,
+      'savedAt': savedAt.toIso8601String(),
+      'filters': filters.toJson(),
+      'results': results.map((result) => result.toJson()).toList(),
+    };
+  }
+
+  List<RidesEntity> toEntities() {
+    return results.map((result) => result.toEntity()).toList(growable: false);
+  }
+}
+
+String _readRequiredString(Object? rawValue, String fieldName) {
+  if (rawValue is! String) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return rawValue;
+}
+
+int _readRequiredInt(Object? rawValue, String fieldName) {
+  if (rawValue is num) {
+    return rawValue.toInt();
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+double _readRequiredDouble(Object? rawValue, String fieldName) {
+  if (rawValue is num) {
+    return rawValue.toDouble();
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+bool _readRequiredBool(Object? rawValue, String fieldName) {
+  if (rawValue is bool) {
+    return rawValue;
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+DateTime _parseRequiredDateTime(Object? rawValue, String fieldName) {
+  if (rawValue is! String) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  final parsed = DateTime.tryParse(rawValue);
+  if (parsed == null) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return parsed;
+}
+
+List<String> _readRequiredStringList(Object? rawValue, String fieldName) {
+  if (rawValue is! List) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  if (rawValue.any((item) => item is! String)) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return List<String>.from(rawValue);
+}

--- a/wheels/lib/features/rides/presentation/providers/rides_providers.dart
+++ b/wheels/lib/features/rides/presentation/providers/rides_providers.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/rides_search_local_datasource.dart';
 import '../../data/datasources/rides_remote_datasource.dart';
 import '../../data/repositories/rides_repository_impl.dart';
 import '../../domain/entities/rides_entity.dart';
@@ -10,6 +11,12 @@ import '../../domain/repositories/rides_repository.dart';
 final ridesRemoteDataSourceProvider = Provider<RidesRemoteDataSource>((ref) {
   return RidesRemoteDataSource(firestore: FirebaseFirestore.instance);
 });
+
+final ridesSearchLocalDataSourceProvider = Provider<RidesSearchLocalDataSource>(
+  (ref) {
+    return RidesSearchLocalDataSource();
+  },
+);
 
 final ridesRepositoryProvider = Provider<RidesRepository>((ref) {
   return RidesRepositoryImpl(

--- a/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -12,6 +14,8 @@ import '../../../../theme/app_radius.dart';
 import '../../../../theme/app_shadows.dart';
 import '../../../../theme/app_spacing.dart';
 import '../../../../theme/app_theme_palette.dart';
+import '../../data/datasources/rides_search_local_datasource.dart';
+import '../../data/models/local_ride_search_cache_model.dart';
 import '../../domain/entities/rides_entity.dart';
 import '../models/ride_listing.dart';
 import '../providers/rides_providers.dart';
@@ -40,21 +44,26 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   final _destinationController = TextEditingController();
   final _dateController = TextEditingController();
 
+  late final RidesSearchLocalDataSource _ridesSearchLocalDataSource;
   DateTime _selectedDate = DateTime.now();
   late DateTime _appliedDate;
   RideSortOption _sort = RideSortOption.smartMatch;
   bool _isResolvingOriginFromGps = false;
+  bool _hasTriggeredSearch = false;
   String? _originLocationError;
   String? _currentLocationSuggestion;
   String _appliedOriginQuery = '';
   String _appliedDestinationQuery = '';
+  LocalRideSearchCacheModel? _cachedSearchCache;
+  String? _lastSavedCacheSignature;
 
   @override
   void initState() {
     super.initState();
+    _ridesSearchLocalDataSource = ref.read(ridesSearchLocalDataSourceProvider);
     _appliedDate = _dateOnly(_selectedDate);
     _dateController.text = _formatDate(_selectedDate);
-    Future.microtask(_prefillOriginWithCurrentLocation);
+    Future.microtask(_initializeSearchState);
   }
 
   @override
@@ -84,6 +93,33 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     } catch (_) {
       // Leave the field empty if location cannot be resolved on screen load.
     }
+  }
+
+  Future<void> _initializeSearchState() async {
+    await _restoreLatestSearch();
+    await _prefillOriginWithCurrentLocation();
+  }
+
+  Future<void> _restoreLatestSearch() async {
+    final cache = await _ridesSearchLocalDataSource.loadLatestSearch();
+    if (!mounted || cache == null) {
+      return;
+    }
+
+    final filters = cache.filters;
+    setState(() {
+      _cachedSearchCache = cache;
+      _hasTriggeredSearch = true;
+      _selectedDate = _dateOnly(filters.selectedDate);
+      _appliedDate = _selectedDate;
+      _sort = filters.sort;
+      _originController.text = filters.originQuery;
+      _destinationController.text = filters.destinationQuery;
+      _dateController.text = _formatDate(_selectedDate);
+      _appliedOriginQuery = filters.originQuery.trim().toLowerCase();
+      _appliedDestinationQuery = filters.destinationQuery.trim().toLowerCase();
+      _lastSavedCacheSignature = _cacheSignature(cache);
+    });
   }
 
   Future<void> _useCurrentLocationAsOrigin() async {
@@ -235,7 +271,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   List<RidesEntity> _applyFilters(List<RidesEntity> rides) {
     final filtered = rides.where((ride) {
       final rideDay = _dateOnly(ride.departureAt);
-      if (rideDay != _appliedDate) {
+      if (rideDay.isBefore(_appliedDate)) {
         return false;
       }
 
@@ -258,6 +294,162 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     );
 
     return filtered;
+  }
+
+  Future<void> _clearFilters() async {
+    final now = _dateOnly(DateTime.now());
+
+    setState(() {
+      _hasTriggeredSearch = false;
+      _sort = RideSortOption.smartMatch;
+      _selectedDate = now;
+      _appliedDate = now;
+      _originController.clear();
+      _destinationController.clear();
+      _dateController.text = _formatDate(now);
+      _appliedOriginQuery = '';
+      _appliedDestinationQuery = '';
+      _cachedSearchCache = null;
+      _lastSavedCacheSignature = null;
+    });
+
+    await _ridesSearchLocalDataSource.clearLatestSearch();
+    if (!mounted) {
+      return;
+    }
+
+    await _prefillOriginWithCurrentLocation();
+  }
+
+  Future<void> _handleDestinationChanged(String value) async {
+    if (value.trim().isNotEmpty || _appliedDestinationQuery.isEmpty) {
+      return;
+    }
+
+    setState(() {
+      _appliedDestinationQuery = '';
+    });
+
+    final rides = ref.read(availableRidesProvider).valueOrNull;
+    if (rides != null) {
+      await _persistLatestSuccessfulSearch(_applyFilters(rides));
+    }
+  }
+
+  Future<void> _applySearch() async {
+    setState(() {
+      _hasTriggeredSearch = true;
+      _appliedOriginQuery = _originController.text.trim().toLowerCase();
+      _appliedDestinationQuery = _destinationController.text
+          .trim()
+          .toLowerCase();
+      _appliedDate = _dateOnly(_selectedDate);
+    });
+
+    final ridesAsync = ref.read(availableRidesProvider);
+    final rides = ridesAsync.valueOrNull;
+    if (rides != null) {
+      await _persistLatestSuccessfulSearch(_applyFilters(rides));
+    }
+  }
+
+  Future<void> _persistLatestSuccessfulSearch(List<RidesEntity> results) async {
+    if (!_hasTriggeredSearch) {
+      return;
+    }
+
+    final cache = LocalRideSearchCacheModel.create(
+      filters: LocalRideSearchFiltersModel(
+        originQuery: _originController.text.trim(),
+        destinationQuery: _destinationController.text.trim(),
+        selectedDate: _appliedDate,
+        sort: _sort,
+      ),
+      results: results,
+    );
+    final nextSignature = _cacheSignature(cache);
+    if (nextSignature == _lastSavedCacheSignature) {
+      return;
+    }
+
+    await _ridesSearchLocalDataSource.saveLatestSearch(cache);
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _cachedSearchCache = cache;
+      _lastSavedCacheSignature = nextSignature;
+    });
+  }
+
+  String _cacheSignature(LocalRideSearchCacheModel cache) {
+    final resultIds = cache.results.map((result) => result.id).join('|');
+    final filters = cache.filters;
+    return [
+      filters.originQuery.trim().toLowerCase(),
+      filters.destinationQuery.trim().toLowerCase(),
+      _dateOnly(filters.selectedDate).toIso8601String(),
+      filters.sort.name,
+      resultIds,
+    ].join('::');
+  }
+
+  Widget _buildResultsSection(
+    List<RidesEntity> results, {
+    bool isCached = false,
+  }) {
+    return Column(
+      children: [
+        if (isCached) ...[
+          _cachedResultsNotice(),
+          const SizedBox(height: AppSpacing.m),
+        ],
+        _sectionTitle('Available Drivers', '${results.length} rides'),
+        const SizedBox(height: AppSpacing.s),
+        if (results.isEmpty) _emptyState(isCached: isCached),
+        for (var index = 0; index < results.length; index++) ...[
+          _RideResultCard(
+            ride: results[index],
+            isBestMatch: _sort == RideSortOption.smartMatch && index == 0,
+            onTap: () =>
+                context.go(AppRoutes.rideDetailsById(results[index].id)),
+          ),
+          const SizedBox(height: AppSpacing.m),
+        ],
+      ],
+    );
+  }
+
+  Widget _cachedResultsNotice() {
+    final palette = context.palette;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: palette.secondary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        border: Border.all(color: palette.secondary.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.offline_bolt_outlined, color: palette.secondary),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: Text(
+              'Showing the latest saved search results while live data is unavailable.',
+              style: TextStyle(
+                color: palette.textPrimary,
+                fontWeight: FontWeight.w600,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -295,24 +487,8 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
             ridesAsync.when(
               data: (rides) {
                 final results = _applyFilters(rides);
-                return Column(
-                  children: [
-                    _sectionTitle('Available Drivers', '${results.length} rides'),
-                    const SizedBox(height: AppSpacing.s),
-                    if (results.isEmpty) _emptyState(),
-                    for (var index = 0; index < results.length; index++) ...[
-                      _RideResultCard(
-                        ride: results[index],
-                        isBestMatch:
-                            _sort == RideSortOption.smartMatch && index == 0,
-                        onTap: () => context.go(
-                          AppRoutes.rideDetailsById(results[index].id),
-                        ),
-                      ),
-                      const SizedBox(height: AppSpacing.m),
-                    ],
-                  ],
-                );
+                unawaited(_persistLatestSuccessfulSearch(results));
+                return _buildResultsSection(results);
               },
               loading: () => const Padding(
                 padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
@@ -370,10 +546,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
                 Expanded(
                   child: Text(
                     _originLocationError!,
-                    style: TextStyle(
-                      color: palette.error,
-                      fontSize: 12,
-                    ),
+                    style: TextStyle(color: palette.error, fontSize: 12),
                   ),
                 ),
               ],
@@ -414,30 +587,44 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
           const SizedBox(height: AppSpacing.m),
           SizedBox(
             width: double.infinity,
-            child: ElevatedButton.icon(
-              onPressed: () {
-                setState(() {
-                  _appliedOriginQuery = _originController.text
-                      .trim()
-                      .toLowerCase();
-                  _appliedDestinationQuery = _destinationController.text
-                      .trim()
-                      .toLowerCase();
-                });
-              },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: palette.accent,
-                foregroundColor: palette.accentForeground,
-                minimumSize: const Size(double.infinity, 50),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.sm),
+            child: Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: _applySearch,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: palette.accent,
+                      foregroundColor: palette.accentForeground,
+                      minimumSize: const Size(double.infinity, 50),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadius.sm),
+                      ),
+                    ),
+                    icon: const Icon(Icons.search),
+                    label: const Text(
+                      'Search Rides',
+                      style: TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                  ),
                 ),
-              ),
-              icon: const Icon(Icons.search),
-              label: const Text(
-                'Search Rides',
-                style: TextStyle(fontWeight: FontWeight.w700),
-              ),
+                const SizedBox(width: AppSpacing.s),
+                OutlinedButton.icon(
+                  onPressed: _clearFilters,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: palette.primary,
+                    side: BorderSide(color: palette.border),
+                    minimumSize: const Size(0, 50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppRadius.sm),
+                    ),
+                  ),
+                  icon: const Icon(Icons.refresh),
+                  label: const Text(
+                    'Clear',
+                    style: TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ],
             ),
           ),
         ],
@@ -514,9 +701,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
       decoration: BoxDecoration(
         color: palette.primary.withValues(alpha: 0.08),
         borderRadius: BorderRadius.circular(AppRadius.sm),
-        border: Border.all(
-          color: palette.primary.withValues(alpha: 0.18),
-        ),
+        border: Border.all(color: palette.primary.withValues(alpha: 0.18)),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -537,10 +722,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
                 const SizedBox(height: 4),
                 Text(
                   'Results are ranked using driver rating, punctuality, university verification, available seats, price, and how soon the ride departs.',
-                  style: TextStyle(
-                    color: palette.textSecondary,
-                    height: 1.35,
-                  ),
+                  style: TextStyle(color: palette.textSecondary, height: 1.35),
                 ),
               ],
             ),
@@ -575,7 +757,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     );
   }
 
-  Widget _emptyState() {
+  Widget _emptyState({bool isCached = false}) {
     final palette = context.palette;
 
     return Container(
@@ -599,7 +781,9 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
           ),
           const SizedBox(height: AppSpacing.xs),
           Text(
-            'Try changing origin, destination or date.',
+            isCached
+                ? 'These are the latest results stored on this device.'
+                : 'Try changing origin, destination or date.',
             textAlign: TextAlign.center,
             style: TextStyle(color: palette.textSecondary),
           ),
@@ -609,6 +793,11 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   }
 
   Widget _loadError(Object error) {
+    final cachedResults = _cachedSearchCache?.toEntities();
+    if (cachedResults != null) {
+      return _buildResultsSection(cachedResults, isCached: true);
+    }
+
     final palette = context.palette;
 
     return Container(
@@ -669,7 +858,12 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
         return TextField(
           controller: textController,
           focusNode: focusNode,
-          onChanged: (value) => controller.text = value,
+          onChanged: (value) {
+            controller.text = value;
+            if (label == 'Destination') {
+              unawaited(_handleDestinationChanged(value));
+            }
+          },
           decoration: InputDecoration(
             labelText: label,
             hintText: hint,
@@ -927,10 +1121,7 @@ class _RideResultCardState extends State<_RideResultCard> {
           ),
           Text(
             detail,
-            style: TextStyle(
-              color: palette.textSecondary,
-              fontSize: 12,
-            ),
+            style: TextStyle(color: palette.textSecondary, fontSize: 12),
           ),
         ],
       ),
@@ -957,11 +1148,7 @@ class _RideResultCardState extends State<_RideResultCard> {
             ),
           ),
         ),
-        Icon(
-          Icons.arrow_forward,
-          color: palette.textSecondary,
-          size: 14,
-        ),
+        Icon(Icons.arrow_forward, color: palette.textSecondary, size: 14),
       ],
     );
   }


### PR DESCRIPTION
## Summary
This PR adds local storage support to `RidesSearchScreen` so the app can restore the user's latest successful search context and provide a local fallback when live ride data is unavailable.

## What Changed
- Added local models to persist ride search filters and search results
- Added a local datasource backed by `SharedPreferences`
- Restored the latest saved filters when reopening `RidesSearchScreen`
- Persisted the latest successful filtered ride results locally
- Added fallback behavior to display cached results when live ride loading fails
- Added safe serialization/deserialization with automatic cleanup for malformed or incompatible stored data

## Storage Design
A single versioned cache entry is stored in local storage:

- Key: `rides_search_cache_v1`

Stored payload structure:
- `version`
- `savedAt`
- `filters`
- `results`

The cached `filters` include:
- `originQuery`
- `destinationQuery`
- `selectedDate`
- `sort`

The cached `results` include the full ride snapshot needed to render the search screen offline or in degraded scenarios.

## Why This Approach
- `SharedPreferences` is sufficient because we only need to persist the latest successful search, not a full offline database
- A single versioned JSON payload keeps filters and results consistent with each other
- Full result snapshots allow reuse even when Firestore is unavailable
- Versioning makes future migrations safer
- Invalid or malformed cached data is removed automatically to avoid crashes

## User Impact
- The last successful search filters are restored when the user reopens the screen
- The latest successful search results remain available locally
- The screen can continue showing useful data during offline or degraded scenarios
- Corrupted or missing local data does not break the screen

## Technical Notes
New components added:
- `LocalRideSearchFiltersModel`
- `LocalRideSearchResultModel`
- `LocalRideSearchCacheModel`
- `RidesSearchLocalDataSource`

Integration points:
- Local datasource provider added to the rides providers layer
- Search state restoration added to `RidesSearchScreen`
- Cache persistence triggered after successful search result resolution
- Cached results shown as fallback when remote loading fails

## Validation
- Verified with `flutter analyze`
