### PR TITLE
Feature: eventual connectivity with online-first for ride search

### DIFF
--- a/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../features/auth/presentation/providers/auth_providers.dart';
 import '../../../../router/app_routes.dart';
+import '../../../../shared/providers/connectivity_provider.dart';
 import '../../../../shared/services/current_location_service.dart';
 import '../../../../shared/ui/app_scaffold.dart';
 import '../../../../shared/widgets/app_bottom_nav.dart';
@@ -56,6 +57,8 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   String _appliedDestinationQuery = '';
   LocalRideSearchCacheModel? _cachedSearchCache;
   String? _lastSavedCacheSignature;
+  bool _isShowingOfflineFallback = false;
+  bool _isRetryingSearch = false;
 
   @override
   void initState() {
@@ -97,7 +100,21 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
 
   Future<void> _initializeSearchState() async {
     await _restoreLatestSearch();
+    await _syncOfflineFallbackWithConnectivity();
     await _prefillOriginWithCurrentLocation();
+  }
+
+  Future<void> _syncOfflineFallbackWithConnectivity() async {
+    final isOnline = await ref
+        .read(connectivityServiceProvider)
+        .hasConnection();
+    if (!mounted || isOnline || _cachedSearchCache == null) {
+      return;
+    }
+
+    setState(() {
+      _isShowingOfflineFallback = true;
+    });
   }
 
   Future<void> _restoreLatestSearch() async {
@@ -311,6 +328,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
       _appliedDestinationQuery = '';
       _cachedSearchCache = null;
       _lastSavedCacheSignature = null;
+      _isShowingOfflineFallback = false;
     });
 
     await _ridesSearchLocalDataSource.clearLatestSearch();
@@ -401,6 +419,18 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   }
 
   Future<void> _applySearch() async {
+    final isOnline = await ref
+        .read(connectivityServiceProvider)
+        .hasConnection();
+    if (!isOnline) {
+      await _showOfflineFallback();
+      return;
+    }
+
+    await _runLiveSearch();
+  }
+
+  Future<void> _runLiveSearch({bool refreshProvider = false}) async {
     final nextOriginQuery = _originController.text.trim();
     final nextDestinationQuery = _destinationController.text.trim();
     final selectedDate = _dateOnly(_selectedDate);
@@ -418,6 +448,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
       _appliedOriginQuery = nextOriginQuery.toLowerCase();
       _appliedDestinationQuery = nextDestinationQuery.toLowerCase();
       _appliedDate = selectedDate;
+      _isShowingOfflineFallback = false;
     });
 
     unawaited(
@@ -430,10 +461,74 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
       ),
     );
 
+    if (refreshProvider) {
+      ref.invalidate(availableRidesProvider);
+    }
+
     final ridesAsync = ref.read(availableRidesProvider);
     final rides = ridesAsync.valueOrNull;
     if (rides != null) {
       await _persistLatestSuccessfulSearch(_applyFilters(rides));
+    }
+  }
+
+  Future<void> _showOfflineFallback() async {
+    await _restoreLatestSearch();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _isShowingOfflineFallback = true;
+    });
+
+    final hasCachedResults = _cachedSearchCache != null;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          hasCachedResults
+              ? 'You are offline. Showing your latest saved ride search.'
+              : 'You are offline and there is no saved ride search on this device yet.',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _retrySearch() async {
+    if (_isRetryingSearch) {
+      return;
+    }
+
+    setState(() {
+      _isRetryingSearch = true;
+    });
+
+    try {
+      final isOnline = await ref
+          .read(connectivityServiceProvider)
+          .hasConnection();
+      if (!mounted) {
+        return;
+      }
+
+      if (!isOnline) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Connection is still unavailable. Try again once you are back online.',
+            ),
+          ),
+        );
+        return;
+      }
+
+      await _runLiveSearch(refreshProvider: true);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isRetryingSearch = false;
+        });
+      }
     }
   }
 
@@ -482,11 +577,12 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   Widget _buildResultsSection(
     List<RidesEntity> results, {
     bool isCached = false,
+    required bool isOnline,
   }) {
     return Column(
       children: [
         if (isCached) ...[
-          _cachedResultsNotice(),
+          _cachedResultsNotice(isOnline: isOnline),
           const SizedBox(height: AppSpacing.m),
         ],
         _sectionTitle('Available Drivers', '${results.length} rides'),
@@ -505,8 +601,24 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     );
   }
 
-  Widget _cachedResultsNotice() {
+  String _formatCacheSavedAt(DateTime value) {
+    final localValue = value.toLocal();
+    final day = localValue.day.toString().padLeft(2, '0');
+    final month = localValue.month.toString().padLeft(2, '0');
+    final hour = localValue.hour.toString().padLeft(2, '0');
+    final minute = localValue.minute.toString().padLeft(2, '0');
+    return '$day/$month/${localValue.year} $hour:$minute';
+  }
+
+  Widget _cachedResultsNotice({required bool isOnline}) {
     final palette = context.palette;
+    final savedAt = _cachedSearchCache?.savedAt;
+    final title = isOnline
+        ? 'Connection restored. You are still viewing cached results.'
+        : 'You are offline. Showing the latest saved results.';
+    final description = savedAt == null
+        ? 'Refresh when a connection is available to get live rides again.'
+        : 'Last saved on ${_formatCacheSavedAt(savedAt)}. Refresh when a connection is available to get live rides again.';
 
     return Container(
       width: double.infinity,
@@ -522,14 +634,104 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
           Icon(Icons.offline_bolt_outlined, color: palette.secondary),
           const SizedBox(width: AppSpacing.s),
           Expanded(
-            child: Text(
-              'Showing the latest saved search results while live data is unavailable.',
-              style: TextStyle(
-                color: palette.textPrimary,
-                fontWeight: FontWeight.w600,
-                height: 1.35,
-              ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w700,
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  description,
+                  style: TextStyle(
+                    color: palette.textSecondary,
+                    fontWeight: FontWeight.w600,
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.s),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: OutlinedButton.icon(
+                    onPressed: isOnline && !_isRetryingSearch
+                        ? _retrySearch
+                        : null,
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: palette.secondary,
+                      side: BorderSide(
+                        color: palette.secondary.withValues(alpha: 0.35),
+                      ),
+                    ),
+                    icon: _isRetryingSearch
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.refresh),
+                    label: Text(
+                      isOnline ? 'Refresh results' : 'Reconnect to refresh',
+                    ),
+                  ),
+                ),
+              ],
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _offlineEmptyState({required bool isOnline}) {
+    final palette = context.palette;
+
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.l),
+      decoration: BoxDecoration(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        boxShadow: AppShadows.sm,
+      ),
+      child: Column(
+        children: [
+          Icon(Icons.cloud_off_outlined, size: 64, color: palette.secondary),
+          const SizedBox(height: AppSpacing.s),
+          Text(
+            'No offline results available',
+            style: TextStyle(
+              fontWeight: FontWeight.w700,
+              fontSize: 18,
+              color: palette.textPrimary,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            isOnline
+                ? 'Connection is back. Retry to load live rides.'
+                : 'This device does not have a saved ride search yet. Connect to the internet and retry.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: palette.textSecondary, height: 1.35),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          OutlinedButton.icon(
+            onPressed: isOnline && !_isRetryingSearch ? _retrySearch : null,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: palette.primary,
+              side: BorderSide(color: palette.border),
+            ),
+            icon: _isRetryingSearch
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.refresh),
+            label: const Text('Retry'),
           ),
         ],
       ),
@@ -541,6 +743,51 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     final palette = context.palette;
     final role = ref.watch(currentUserRoleProvider);
     final ridesAsync = ref.watch(availableRidesProvider);
+    final connectivityAsync = ref.watch(connectivityStatusProvider);
+    final isOnline = connectivityAsync.valueOrNull ?? true;
+    final cachedResults = _cachedSearchCache?.toEntities();
+
+    ref.listen<AsyncValue<bool>>(connectivityStatusProvider, (_, next) {
+      next.whenData((hasConnection) {
+        if (!mounted || hasConnection || _cachedSearchCache == null) {
+          return;
+        }
+
+        if (_isShowingOfflineFallback) {
+          return;
+        }
+
+        setState(() {
+          _isShowingOfflineFallback = true;
+        });
+      });
+    });
+
+    final shouldShowCachedResults =
+        cachedResults != null && (_isShowingOfflineFallback || !isOnline);
+    final shouldShowOfflineEmptyState =
+        cachedResults == null && (_isShowingOfflineFallback || !isOnline);
+
+    final resultsSection = shouldShowCachedResults
+        ? _buildResultsSection(
+            cachedResults,
+            isCached: true,
+            isOnline: isOnline,
+          )
+        : shouldShowOfflineEmptyState
+        ? _offlineEmptyState(isOnline: isOnline)
+        : ridesAsync.when(
+            data: (rides) {
+              final results = _applyFilters(rides);
+              unawaited(_persistLatestSuccessfulSearch(results));
+              return _buildResultsSection(results, isOnline: isOnline);
+            },
+            loading: () => const Padding(
+              padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (error, _) => _loadError(error, isOnline: isOnline),
+          );
 
     return AppScaffold(
       title: 'Rides',
@@ -562,24 +809,15 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
           children: [
             _searchCard(),
             const SizedBox(height: AppSpacing.m),
-            _sortBar(),
+            _sortBar(
+              isInteractionDisabled: _isShowingOfflineFallback || !isOnline,
+            ),
             if (_sort == RideSortOption.smartMatch) ...[
               const SizedBox(height: AppSpacing.m),
               _smartMatchNotice(),
             ],
             const SizedBox(height: AppSpacing.l),
-            ridesAsync.when(
-              data: (rides) {
-                final results = _applyFilters(rides);
-                unawaited(_persistLatestSuccessfulSearch(results));
-                return _buildResultsSection(results);
-              },
-              loading: () => const Padding(
-                padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
-                child: Center(child: CircularProgressIndicator()),
-              ),
-              error: (error, _) => _loadError(error),
-            ),
+            resultsSection,
             const SizedBox(height: AppSpacing.s),
           ],
         ),
@@ -716,7 +954,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     );
   }
 
-  Widget _sortBar() {
+  Widget _sortBar({bool isInteractionDisabled = false}) {
     final palette = context.palette;
 
     return Row(
@@ -761,11 +999,13 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
                           : palette.primary,
                       fontWeight: FontWeight.w600,
                     ),
-                    onSelected: (_) {
-                      setState(() {
-                        _sort = option;
-                      });
-                    },
+                    onSelected: isInteractionDisabled
+                        ? null
+                        : (_) {
+                            setState(() {
+                              _sort = option;
+                            });
+                          },
                   ),
                 );
               }).toList(),
@@ -876,10 +1116,26 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     );
   }
 
-  Widget _loadError(Object error) {
+  Widget _loadError(Object error, {required bool isOnline}) {
     final cachedResults = _cachedSearchCache?.toEntities();
-    if (cachedResults != null) {
-      return _buildResultsSection(cachedResults, isCached: true);
+    if (cachedResults != null && !isOnline) {
+      if (!_isShowingOfflineFallback) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) {
+            return;
+          }
+
+          setState(() {
+            _isShowingOfflineFallback = true;
+          });
+        });
+      }
+
+      return _buildResultsSection(
+        cachedResults,
+        isCached: true,
+        isOnline: isOnline,
+      );
     }
 
     final palette = context.palette;
@@ -905,9 +1161,27 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
           ),
           const SizedBox(height: AppSpacing.xs),
           Text(
-            error.toString(),
+            isOnline
+                ? error.toString()
+                : 'Your connection is unavailable and there are no cached results to show yet.',
             textAlign: TextAlign.center,
             style: TextStyle(color: palette.textSecondary),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          OutlinedButton.icon(
+            onPressed: isOnline && !_isRetryingSearch ? _retrySearch : null,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: palette.primary,
+              side: BorderSide(color: palette.border),
+            ),
+            icon: _isRetryingSearch
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.refresh),
+            label: const Text('Retry'),
           ),
         ],
       ),

--- a/wheels/lib/shared/providers/connectivity_provider.dart
+++ b/wheels/lib/shared/providers/connectivity_provider.dart
@@ -1,0 +1,29 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ConnectivityService {
+  const ConnectivityService();
+
+  Future<bool> hasConnection() async {
+    final results = await Connectivity().checkConnectivity();
+    return _isConnected(results);
+  }
+
+  Stream<bool> watchConnection() {
+    return Connectivity().onConnectivityChanged.map(_isConnected).distinct();
+  }
+
+  bool _isConnected(List<ConnectivityResult> results) {
+    return results.any((result) => result != ConnectivityResult.none);
+  }
+}
+
+final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
+  return const ConnectivityService();
+});
+
+final connectivityStatusProvider = StreamProvider<bool>((ref) async* {
+  final service = ref.watch(connectivityServiceProvider);
+  yield await service.hasConnection();
+  yield* service.watchConnection();
+});

--- a/wheels/pubspec.lock
+++ b/wheels/pubspec.lock
@@ -113,6 +113,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   crypto:
     dependency: transitive
     description:
@@ -532,10 +548,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -552,6 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   package_info_plus:
     dependency: transitive
     description:
@@ -745,10 +769,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/wheels/pubspec.yaml
+++ b/wheels/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   firebase_messaging: ^16.0.2
   fl_chart: ^0.70.2
   shared_preferences: ^2.5.3
+  connectivity_plus: ^7.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR implements eventual connectivity behavior for RidesSearchScreen using an online-first approach with cached offline fallback.

When the device is offline, the screen no longer behaves as if it were performing a live search. Instead, it restores and displays the latest locally saved search results, clearly informs the user that the data is cached and may be outdated, and avoids presenting stale data as real-time content. A retry action was also added so users can refresh the search normally once connectivity is restored.

Key changes:

Added connectivity state detection before running ride searches
Blocked live search execution while offline
Reused the latest locally stored search results as fallback
Added UI messaging to indicate offline/cached results
Added retry support to refresh results after reconnection