### PR TITLE
Feature: local cache for ridedetailsscreen saved in SharedPreferences

### DIFF
--- a/wheels/lib/features/rides/data/datasources/ride_details_local_datasource.dart
+++ b/wheels/lib/features/rides/data/datasources/ride_details_local_datasource.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/local_ride_details_cache_model.dart';
+
+class RideDetailsLocalDataSource {
+  static const String _cacheKey = 'ride_details_cache_v1';
+
+  Future<LocalRideDetailsCacheModel?> loadLatestRideDetails() async {
+    final prefs = await SharedPreferences.getInstance();
+    final rawCache = prefs.getString(_cacheKey);
+    if (rawCache == null || rawCache.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      final decoded = jsonDecode(rawCache);
+      if (decoded is! Map) {
+        throw const FormatException('Stored ride details cache is invalid.');
+      }
+
+      return LocalRideDetailsCacheModel.fromJson(
+        Map<String, dynamic>.from(decoded),
+      );
+    } catch (_) {
+      await clearLatestRideDetails();
+      return null;
+    }
+  }
+
+  Future<void> saveLatestRideDetails(LocalRideDetailsCacheModel cache) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_cacheKey, jsonEncode(cache.toJson()));
+  }
+
+  Future<void> clearLatestRideDetails() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_cacheKey);
+  }
+}

--- a/wheels/lib/features/rides/data/models/local_ride_details_cache_model.dart
+++ b/wheels/lib/features/rides/data/models/local_ride_details_cache_model.dart
@@ -1,0 +1,293 @@
+import '../../domain/entities/rides_entity.dart';
+
+class LocalRideDetailsCacheModel {
+  const LocalRideDetailsCacheModel({
+    required this.version,
+    required this.rideId,
+    required this.savedAt,
+    required this.ride,
+  });
+
+  static const int currentVersion = 1;
+
+  final int version;
+  final String rideId;
+  final DateTime savedAt;
+  final LocalRideDetailsModel ride;
+
+  factory LocalRideDetailsCacheModel.create({required RidesEntity ride}) {
+    return LocalRideDetailsCacheModel(
+      version: currentVersion,
+      rideId: ride.id,
+      savedAt: DateTime.now().toUtc(),
+      ride: LocalRideDetailsModel.fromEntity(ride),
+    );
+  }
+
+  factory LocalRideDetailsCacheModel.fromJson(Map<String, dynamic> json) {
+    final version = _readRequiredInt(json['version'], 'version');
+    if (version != currentVersion) {
+      throw FormatException('Unsupported cache version: $version');
+    }
+
+    final rawRide = json['ride'];
+    if (rawRide is! Map) {
+      throw const FormatException('Invalid ride payload.');
+    }
+
+    final ride = LocalRideDetailsModel.fromJson(
+      Map<String, dynamic>.from(rawRide),
+    );
+    final rideId = _readRequiredString(json['rideId'], 'rideId');
+    if (ride.id != rideId) {
+      throw const FormatException('Stored ride cache is inconsistent.');
+    }
+
+    return LocalRideDetailsCacheModel(
+      version: version,
+      rideId: rideId,
+      savedAt: _parseRequiredDateTime(json['savedAt'], 'savedAt'),
+      ride: ride,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'version': version,
+      'rideId': rideId,
+      'savedAt': savedAt.toIso8601String(),
+      'ride': ride.toJson(),
+    };
+  }
+
+  bool matchesRide(String currentRideId) {
+    return rideId == currentRideId && ride.id == currentRideId;
+  }
+
+  bool isExpired({Duration maxAge = const Duration(hours: 6)}) {
+    final now = DateTime.now().toUtc();
+    if (savedAt.isAfter(now.add(const Duration(minutes: 5)))) {
+      return true;
+    }
+    return now.difference(savedAt.toUtc()) > maxAge;
+  }
+
+  RidesEntity toEntity() => ride.toEntity();
+}
+
+class LocalRideDetailsModel {
+  const LocalRideDetailsModel({
+    required this.id,
+    required this.driverId,
+    required this.driverName,
+    required this.driverEmail,
+    required this.origin,
+    required this.destination,
+    required this.departureAt,
+    required this.estimatedDurationMinutes,
+    required this.totalSeats,
+    required this.availableSeats,
+    required this.pricePerSeat,
+    required this.paymentOption,
+    required this.status,
+    required this.notes,
+    required this.passengerIds,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.driverRating,
+    required this.reviewCount,
+    required this.onTimeRate,
+    required this.verifiedByUniversity,
+  });
+
+  final String id;
+  final String driverId;
+  final String driverName;
+  final String driverEmail;
+  final String origin;
+  final String destination;
+  final DateTime departureAt;
+  final int estimatedDurationMinutes;
+  final int totalSeats;
+  final int availableSeats;
+  final int pricePerSeat;
+  final RidePaymentOption paymentOption;
+  final String status;
+  final String notes;
+  final List<String> passengerIds;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final double driverRating;
+  final int reviewCount;
+  final int onTimeRate;
+  final bool verifiedByUniversity;
+
+  factory LocalRideDetailsModel.fromEntity(RidesEntity entity) {
+    return LocalRideDetailsModel(
+      id: entity.id,
+      driverId: entity.driverId,
+      driverName: entity.driverName,
+      driverEmail: entity.driverEmail,
+      origin: entity.origin,
+      destination: entity.destination,
+      departureAt: entity.departureAt,
+      estimatedDurationMinutes: entity.estimatedDurationMinutes,
+      totalSeats: entity.totalSeats,
+      availableSeats: entity.availableSeats,
+      pricePerSeat: entity.pricePerSeat,
+      paymentOption: entity.paymentOption,
+      status: entity.status,
+      notes: entity.notes,
+      passengerIds: List<String>.from(entity.passengerIds),
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      driverRating: entity.driverRating,
+      reviewCount: entity.reviewCount,
+      onTimeRate: entity.onTimeRate,
+      verifiedByUniversity: entity.verifiedByUniversity,
+    );
+  }
+
+  factory LocalRideDetailsModel.fromJson(Map<String, dynamic> json) {
+    return LocalRideDetailsModel(
+      id: _readRequiredString(json['id'], 'id'),
+      driverId: _readRequiredString(json['driverId'], 'driverId'),
+      driverName: _readRequiredString(json['driverName'], 'driverName'),
+      driverEmail: _readRequiredString(json['driverEmail'], 'driverEmail'),
+      origin: _readRequiredString(json['origin'], 'origin'),
+      destination: _readRequiredString(json['destination'], 'destination'),
+      departureAt: _parseRequiredDateTime(json['departureAt'], 'departureAt'),
+      estimatedDurationMinutes: _readRequiredInt(
+        json['estimatedDurationMinutes'],
+        'estimatedDurationMinutes',
+      ),
+      totalSeats: _readRequiredInt(json['totalSeats'], 'totalSeats'),
+      availableSeats: _readRequiredInt(json['availableSeats'], 'availableSeats'),
+      pricePerSeat: _readRequiredInt(json['pricePerSeat'], 'pricePerSeat'),
+      paymentOption: ridePaymentOptionFromStorage(
+        _readRequiredString(json['paymentOption'], 'paymentOption'),
+      ),
+      status: _readRequiredString(json['status'], 'status'),
+      notes: _readRequiredString(json['notes'], 'notes'),
+      passengerIds: _readRequiredStringList(json['passengerIds'], 'passengerIds'),
+      createdAt: _parseRequiredDateTime(json['createdAt'], 'createdAt'),
+      updatedAt: _parseRequiredDateTime(json['updatedAt'], 'updatedAt'),
+      driverRating: _readRequiredDouble(json['driverRating'], 'driverRating'),
+      reviewCount: _readRequiredInt(json['reviewCount'], 'reviewCount'),
+      onTimeRate: _readRequiredInt(json['onTimeRate'], 'onTimeRate'),
+      verifiedByUniversity: _readRequiredBool(
+        json['verifiedByUniversity'],
+        'verifiedByUniversity',
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'driverId': driverId,
+      'driverName': driverName,
+      'driverEmail': driverEmail,
+      'origin': origin,
+      'destination': destination,
+      'departureAt': departureAt.toIso8601String(),
+      'estimatedDurationMinutes': estimatedDurationMinutes,
+      'totalSeats': totalSeats,
+      'availableSeats': availableSeats,
+      'pricePerSeat': pricePerSeat,
+      'paymentOption': paymentOption.storageValue,
+      'status': status,
+      'notes': notes,
+      'passengerIds': passengerIds,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
+      'driverRating': driverRating,
+      'reviewCount': reviewCount,
+      'onTimeRate': onTimeRate,
+      'verifiedByUniversity': verifiedByUniversity,
+    };
+  }
+
+  RidesEntity toEntity() {
+    return RidesEntity(
+      id: id,
+      driverId: driverId,
+      driverName: driverName,
+      driverEmail: driverEmail,
+      origin: origin,
+      destination: destination,
+      departureAt: departureAt,
+      estimatedDurationMinutes: estimatedDurationMinutes,
+      totalSeats: totalSeats,
+      availableSeats: availableSeats,
+      pricePerSeat: pricePerSeat,
+      paymentOption: paymentOption,
+      status: status,
+      notes: notes,
+      passengerIds: passengerIds,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      driverRating: driverRating,
+      reviewCount: reviewCount,
+      onTimeRate: onTimeRate,
+      verifiedByUniversity: verifiedByUniversity,
+    );
+  }
+}
+
+String _readRequiredString(Object? rawValue, String fieldName) {
+  if (rawValue is! String) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return rawValue;
+}
+
+int _readRequiredInt(Object? rawValue, String fieldName) {
+  if (rawValue is num) {
+    return rawValue.toInt();
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+double _readRequiredDouble(Object? rawValue, String fieldName) {
+  if (rawValue is num) {
+    return rawValue.toDouble();
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+bool _readRequiredBool(Object? rawValue, String fieldName) {
+  if (rawValue is bool) {
+    return rawValue;
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+DateTime _parseRequiredDateTime(Object? rawValue, String fieldName) {
+  if (rawValue is! String) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  final parsed = DateTime.tryParse(rawValue);
+  if (parsed == null) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return parsed;
+}
+
+List<String> _readRequiredStringList(Object? rawValue, String fieldName) {
+  if (rawValue is! List) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  if (rawValue.any((item) => item is! String)) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return List<String>.from(rawValue);
+}

--- a/wheels/lib/features/rides/presentation/providers/rides_providers.dart
+++ b/wheels/lib/features/rides/presentation/providers/rides_providers.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/ride_details_local_datasource.dart';
 import '../../data/datasources/rides_search_local_datasource.dart';
 import '../../data/datasources/rides_remote_datasource.dart';
 import '../../data/repositories/rides_repository_impl.dart';
@@ -17,6 +18,12 @@ final ridesSearchLocalDataSourceProvider = Provider<RidesSearchLocalDataSource>(
     return RidesSearchLocalDataSource();
   },
 );
+
+final rideDetailsLocalDataSourceProvider = Provider<RideDetailsLocalDataSource>((
+  ref,
+) {
+  return RideDetailsLocalDataSource();
+});
 
 final ridesRepositoryProvider = Provider<RidesRepository>((ref) {
   return RidesRepositoryImpl(

--- a/wheels/lib/features/rides/presentation/screens/ride_details_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/ride_details_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../features/auth/domain/entities/auth_entity.dart';
 import '../../../../features/auth/presentation/providers/auth_providers.dart';
 import '../../../../router/app_routes.dart';
 import '../../../../shared/ui/app_scaffold.dart';
@@ -11,6 +12,7 @@ import '../../../../theme/app_radius.dart';
 import '../../../../theme/app_shadows.dart';
 import '../../../../theme/app_spacing.dart';
 import '../../../../theme/app_theme_palette.dart';
+import '../../data/models/local_ride_details_cache_model.dart';
 import '../../domain/entities/rides_entity.dart';
 import '../models/ride_listing.dart';
 import '../providers/rides_providers.dart';
@@ -25,6 +27,114 @@ class RideDetailsScreen extends ConsumerStatefulWidget {
 }
 
 class _RideDetailsScreenState extends ConsumerState<RideDetailsScreen> {
+  LocalRideDetailsCacheModel? _cachedRideDetails;
+  bool _hasLoadedCachedRide = false;
+  bool _isUsingCachedFallback = false;
+  String? _lastSavedRideSignature;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCachedRideDetails();
+  }
+
+  @override
+  void didUpdateWidget(covariant RideDetailsScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.rideId == widget.rideId) {
+      return;
+    }
+
+    setState(() {
+      _cachedRideDetails = null;
+      _hasLoadedCachedRide = false;
+      _isUsingCachedFallback = false;
+      _lastSavedRideSignature = null;
+    });
+    _loadCachedRideDetails();
+  }
+
+  Future<void> _loadCachedRideDetails() async {
+    final localDataSource = ref.read(rideDetailsLocalDataSourceProvider);
+    final cache = await localDataSource.loadLatestRideDetails();
+    if (!mounted) {
+      return;
+    }
+
+    if (cache == null) {
+      setState(() {
+        _hasLoadedCachedRide = true;
+      });
+      return;
+    }
+
+    if (!cache.matchesRide(widget.rideId) || cache.isExpired()) {
+      await localDataSource.clearLatestRideDetails();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _cachedRideDetails = null;
+        _hasLoadedCachedRide = true;
+        _isUsingCachedFallback = false;
+        _lastSavedRideSignature = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _cachedRideDetails = cache;
+      _hasLoadedCachedRide = true;
+      _isUsingCachedFallback = false;
+      _lastSavedRideSignature = _rideSignature(cache.toEntity());
+    });
+  }
+
+  Future<void> _saveCachedRideDetails(RidesEntity ride) async {
+    final cache = LocalRideDetailsCacheModel.create(ride: ride);
+    final nextSignature = _rideSignature(ride);
+    if (_lastSavedRideSignature == nextSignature) {
+      return;
+    }
+
+    await ref
+        .read(rideDetailsLocalDataSourceProvider)
+        .saveLatestRideDetails(cache);
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _cachedRideDetails = cache;
+      _isUsingCachedFallback = false;
+      _lastSavedRideSignature = nextSignature;
+    });
+  }
+
+  Future<void> _clearCachedRideDetails() async {
+    await ref.read(rideDetailsLocalDataSourceProvider).clearLatestRideDetails();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _cachedRideDetails = null;
+      _isUsingCachedFallback = false;
+      _lastSavedRideSignature = null;
+    });
+  }
+
+  String _rideSignature(RidesEntity ride) {
+    return [
+      ride.id,
+      ride.updatedAt.toIso8601String(),
+      ride.availableSeats.toString(),
+      ride.status,
+      ride.passengerIds.join('|'),
+    ].join('::');
+  }
+
   @override
   Widget build(BuildContext context) {
     final role = ref.watch(currentUserRoleProvider);
@@ -35,6 +145,30 @@ class _RideDetailsScreenState extends ConsumerState<RideDetailsScreen> {
     final applyState = ref.watch(rideApplicationControllerProvider);
     final currentUser = ref.watch(authUserProvider);
     final palette = context.palette;
+    final cachedRide = _cachedRideDetails?.toEntity();
+
+    ref.listen<AsyncValue<RidesEntity?>>(rideProvider(widget.rideId), (
+      previous,
+      next,
+    ) {
+      next.whenOrNull(
+        data: (ride) async {
+          if (ride == null) {
+            await _clearCachedRideDetails();
+            return;
+          }
+          await _saveCachedRideDetails(ride);
+        },
+        error: (_, _) {
+          if (!mounted || cachedRide == null) {
+            return;
+          }
+          setState(() {
+            _isUsingCachedFallback = true;
+          });
+        },
+      );
+    });
 
     ref.listen<AsyncValue<void>>(rideApplicationControllerProvider, (
       previous,
@@ -79,164 +213,215 @@ class _RideDetailsScreenState extends ConsumerState<RideDetailsScreen> {
             return const Center(child: Text('Ride not found'));
           }
 
-          final passengerApplication = applicationAsync.valueOrNull;
-          final isOwnRide = currentUser?.uid == ride.driverId;
-          final hasApplied = passengerApplication != null;
-          final canApply =
-              !isOwnRide &&
-              ride.isOpen &&
-              ride.hasAvailableSeats &&
-              !hasApplied &&
-              currentUser != null;
-          final canOpenPayment = hasApplied && !isOwnRide;
+          return _buildRideContent(
+            ride: ride,
+            palette: palette,
+            currentUser: currentUser,
+            applicationAsync: applicationAsync,
+            applyState: applyState,
+          );
+        },
+        loading: () {
+          if (!_hasLoadedCachedRide) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (cachedRide == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
 
-          return ListView(
+          return _buildRideContent(
+            ride: cachedRide,
+            palette: palette,
+            currentUser: currentUser,
+            applicationAsync: applicationAsync,
+            applyState: applyState,
+            showCachedNotice: true,
+            cachedNoticeTitle: 'Showing saved ride details',
+            cachedNoticeMessage:
+                'We loaded the latest saved ride while refreshing live availability.',
+          );
+        },
+        error: (error, _) {
+          if (cachedRide != null) {
+            return _buildRideContent(
+              ride: cachedRide,
+              palette: palette,
+              currentUser: currentUser,
+              applicationAsync: applicationAsync,
+              applyState: applyState,
+              showCachedNotice: true,
+              cachedNoticeTitle: 'Offline fallback in use',
+              cachedNoticeMessage:
+                  'Live ride data is unavailable right now. You are seeing the latest saved version.',
+            );
+          }
+
+          return Center(
+            child: Text(error.toString(), textAlign: TextAlign.center),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildRideContent({
+    required RidesEntity ride,
+    required AppThemePalette palette,
+    required AuthEntity? currentUser,
+    required AsyncValue<RideApplicationEntity?> applicationAsync,
+    required AsyncValue<void> applyState,
+    bool showCachedNotice = false,
+    String? cachedNoticeTitle,
+    String? cachedNoticeMessage,
+  }) {
+    final passengerApplication = applicationAsync.valueOrNull;
+    final isOwnRide = currentUser?.uid == ride.driverId;
+    final hasApplied = passengerApplication != null;
+    final canApply =
+        !isOwnRide &&
+        ride.isOpen &&
+        ride.hasAvailableSeats &&
+        !hasApplied &&
+        currentUser != null &&
+        !showCachedNotice;
+    final canOpenPayment = hasApplied && !isOwnRide;
+
+    return ListView(
+      children: [
+        if (showCachedNotice) ...[
+          _cachedRideNotice(
+            title: cachedNoticeTitle ?? 'Saved ride details',
+            message: cachedNoticeMessage ?? 'You are seeing locally saved data.',
+          ),
+          const SizedBox(height: AppSpacing.m),
+        ],
+        Container(
+          padding: const EdgeInsets.all(AppSpacing.m),
+          decoration: BoxDecoration(
+            color: palette.card,
+            borderRadius: BorderRadius.circular(AppRadius.sm),
+            boxShadow: AppShadows.sm,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                padding: const EdgeInsets.all(AppSpacing.m),
-                decoration: BoxDecoration(
-                  color: palette.card,
-                  borderRadius: BorderRadius.circular(AppRadius.sm),
-                  boxShadow: AppShadows.sm,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        CircleAvatar(
-                          backgroundColor: palette.primary,
-                          child: Text(
-                            ride.driverInitials,
-                            style: TextStyle(color: palette.primaryForeground),
-                          ),
-                        ),
-                        const SizedBox(width: AppSpacing.s),
-                        Expanded(
-                          child: Text(
-                            ride.driverName,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.w700,
-                              fontSize: 18,
-                            ),
-                          ),
-                        ),
-                        Text(
-                          ride.priceLabel,
-                          style: TextStyle(
-                            color: palette.primary,
-                            fontSize: 24,
-                            fontWeight: FontWeight.w800,
-                          ),
-                        ),
-                      ],
+              Row(
+                children: [
+                  CircleAvatar(
+                    backgroundColor: palette.primary,
+                    child: Text(
+                      ride.driverInitials,
+                      style: TextStyle(color: palette.primaryForeground),
                     ),
-                    const SizedBox(height: AppSpacing.m),
-                    _DetailRow(Icons.trip_origin, 'Origin', ride.origin),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.place_outlined,
-                      'Destination',
-                      ride.destination,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.calendar_month_outlined,
-                      'Date',
-                      ride.dateLabel,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.schedule_outlined,
-                      'Departure',
-                      ride.departureLabel,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.timer_outlined,
-                      'Duration',
-                      ride.durationLabel,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.event_seat_outlined,
-                      'Seats left',
-                      '${ride.availableSeats} of ${ride.totalSeats}',
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      ride.acceptsCardPayments
-                          ? Icons.credit_card_outlined
-                          : Icons.account_balance_outlined,
-                      'Payment',
-                      ride.paymentOptionLabel,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.info_outline,
-                      'Status',
-                      _statusLabel(ride.status),
-                    ),
-                    if (ride.notes.trim().isNotEmpty) ...[
-                      const SizedBox(height: AppSpacing.s),
-                      _DetailRow(Icons.notes_outlined, 'Notes', ride.notes),
-                    ],
-                  ],
-                ),
-              ),
-              if (ride.acceptsCardPayments) ...[
-                const SizedBox(height: AppSpacing.m),
-                _CardPayoutEstimateCard(ride: ride),
-              ],
-              const SizedBox(height: AppSpacing.m),
-              if (isOwnRide)
-                _messageCard(
-                  'This is your ride',
-                  'Passengers can already see it in the search list and apply from there.',
-                )
-              else if (hasApplied)
-                _messageCard(
-                  'Application sent',
-                  'You already applied to this ride. We will keep this seat linked to your account.',
-                )
-              else if (!ride.hasAvailableSeats)
-                _messageCard(
-                  'Ride is full',
-                  'All seats have already been taken for this trip.',
-                )
-              else if (!ride.isOpen)
-                _messageCard(
-                  'Ride unavailable',
-                  'This ride is no longer open for new passengers.',
-                ),
-              const SizedBox(height: AppSpacing.s),
-              ElevatedButton(
-                onPressed: canApply && !applyState.isLoading
-                    ? () async {
-                        await ref
-                            .read(rideApplicationControllerProvider.notifier)
-                            .applyToRide(
-                              rideId: ride.id,
-                              passengerId: currentUser.uid,
-                              passengerName: currentUser.fullName,
-                              passengerEmail: currentUser.email,
-                            );
-                      }
-                    : canOpenPayment
-                    ? () => context.go(AppRoutes.paymentByRideId(ride.id))
-                    : null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: palette.accent,
-                  foregroundColor: palette.accentForeground,
-                  disabledBackgroundColor: palette.surfaceMuted,
-                  disabledForegroundColor: palette.textSecondary,
-                  minimumSize: const Size(double.infinity, 50),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(AppRadius.sm),
                   ),
-                ),
-                child: Text(
-                  _actionLabel(
+                  const SizedBox(width: AppSpacing.s),
+                  Expanded(
+                    child: Text(
+                      ride.driverName,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w700,
+                        fontSize: 18,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    ride.priceLabel,
+                    style: TextStyle(
+                      color: palette.primary,
+                      fontSize: 24,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.m),
+              _DetailRow(Icons.trip_origin, 'Origin', ride.origin),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.place_outlined, 'Destination', ride.destination),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.calendar_month_outlined, 'Date', ride.dateLabel),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.schedule_outlined, 'Departure', ride.departureLabel),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.timer_outlined, 'Duration', ride.durationLabel),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(
+                Icons.event_seat_outlined,
+                'Seats left',
+                '${ride.availableSeats} of ${ride.totalSeats}',
+              ),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(
+                ride.acceptsCardPayments
+                    ? Icons.credit_card_outlined
+                    : Icons.account_balance_outlined,
+                'Payment',
+                ride.paymentOptionLabel,
+              ),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.info_outline, 'Status', _statusLabel(ride.status)),
+              if (ride.notes.trim().isNotEmpty) ...[
+                const SizedBox(height: AppSpacing.s),
+                _DetailRow(Icons.notes_outlined, 'Notes', ride.notes),
+              ],
+            ],
+          ),
+        ),
+        if (ride.acceptsCardPayments) ...[
+          const SizedBox(height: AppSpacing.m),
+          _CardPayoutEstimateCard(ride: ride),
+        ],
+        const SizedBox(height: AppSpacing.m),
+        if (isOwnRide)
+          _messageCard(
+            'This is your ride',
+            'Passengers can already see it in the search list and apply from there.',
+          )
+        else if (hasApplied)
+          _messageCard(
+            'Application sent',
+            'You already applied to this ride. We will keep this seat linked to your account.',
+          )
+        else if (!ride.hasAvailableSeats)
+          _messageCard(
+            'Ride is full',
+            'All seats have already been taken for this trip.',
+          )
+        else if (!ride.isOpen)
+          _messageCard(
+            'Ride unavailable',
+            'This ride is no longer open for new passengers.',
+          ),
+        const SizedBox(height: AppSpacing.s),
+        ElevatedButton(
+          onPressed: canApply && !applyState.isLoading
+              ? () async {
+                  await ref
+                      .read(rideApplicationControllerProvider.notifier)
+                      .applyToRide(
+                        rideId: ride.id,
+                        passengerId: currentUser.uid,
+                        passengerName: currentUser.fullName,
+                        passengerEmail: currentUser.email,
+                      );
+                }
+              : canOpenPayment && !showCachedNotice
+              ? () => context.go(AppRoutes.paymentByRideId(ride.id))
+              : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: palette.accent,
+            foregroundColor: palette.accentForeground,
+            disabledBackgroundColor: palette.surfaceMuted,
+            disabledForegroundColor: palette.textSecondary,
+            minimumSize: const Size(double.infinity, 50),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadius.sm),
+            ),
+          ),
+          child: Text(
+            showCachedNotice
+                ? 'Waiting for live ride details'
+                : _actionLabel(
                     isOwnRide: isOwnRide,
                     hasApplied: hasApplied,
                     passengerApplication: passengerApplication,
@@ -245,16 +430,82 @@ class _RideDetailsScreenState extends ConsumerState<RideDetailsScreen> {
                     hasAvailableSeats: ride.hasAvailableSeats,
                     isLoading: applyState.isLoading,
                   ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _cachedRideNotice({
+    required String title,
+    required String message,
+  }) {
+    final palette = context.palette;
+    final savedAtLabel = _cachedRideDetails == null
+        ? null
+        : 'Saved ${_formatSavedAt(_cachedRideDetails!.savedAt)}';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: palette.secondary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        border: Border.all(color: palette.secondary.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            _isUsingCachedFallback
+                ? Icons.cloud_off_outlined
+                : Icons.offline_bolt_outlined,
+            color: palette.secondary,
+          ),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-            ],
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, _) =>
-            Center(child: Text(error.toString(), textAlign: TextAlign.center)),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  message,
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w600,
+                    height: 1.35,
+                  ),
+                ),
+                if (savedAtLabel != null) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    savedAtLabel,
+                    style: TextStyle(color: palette.textSecondary),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
       ),
     );
+  }
+
+  String _formatSavedAt(DateTime savedAt) {
+    final local = savedAt.toLocal();
+    final day = local.day.toString().padLeft(2, '0');
+    final month = local.month.toString().padLeft(2, '0');
+    final year = local.year.toString();
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
+    return 'on $day/$month/$year at $hour:$minute';
   }
 
   String _statusLabel(String status) {


### PR DESCRIPTION
This PR adds local caching to `RideDetailsScreen` so the latest viewed ride can be displayed faster on future visits and still be shown when live data is temporarily unavailable. It introduces a dedicated local cache model for ride details, persists successful fetches in `SharedPreferences`, hydrates the screen from cached data on startup before the network refresh completes, and falls back to that cached snapshot when the remote fetch fails. The implementation also includes cache validation and invalidation rules based on versioning, ride consistency, and age, plus a visible UI notice to clearly indicate when the screen is showing saved or stale fallback data instead of fresh network data.