### PR TITLE
Feature/protect critical ridedetails actions when offline #81

### DIFF
--- a/wheels/lib/features/rides/data/datasources/ride_details_local_datasource.dart
+++ b/wheels/lib/features/rides/data/datasources/ride_details_local_datasource.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/local_ride_details_cache_model.dart';
+
+class RideDetailsLocalDataSource {
+  static const String _cacheKey = 'ride_details_cache_v1';
+
+  Future<LocalRideDetailsCacheModel?> loadLatestRideDetails() async {
+    final prefs = await SharedPreferences.getInstance();
+    final rawCache = prefs.getString(_cacheKey);
+    if (rawCache == null || rawCache.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      final decoded = jsonDecode(rawCache);
+      if (decoded is! Map) {
+        throw const FormatException('Stored ride details cache is invalid.');
+      }
+
+      return LocalRideDetailsCacheModel.fromJson(
+        Map<String, dynamic>.from(decoded),
+      );
+    } catch (_) {
+      await clearLatestRideDetails();
+      return null;
+    }
+  }
+
+  Future<void> saveLatestRideDetails(LocalRideDetailsCacheModel cache) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_cacheKey, jsonEncode(cache.toJson()));
+  }
+
+  Future<void> clearLatestRideDetails() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_cacheKey);
+  }
+}

--- a/wheels/lib/features/rides/data/models/local_ride_details_cache_model.dart
+++ b/wheels/lib/features/rides/data/models/local_ride_details_cache_model.dart
@@ -1,0 +1,293 @@
+import '../../domain/entities/rides_entity.dart';
+
+class LocalRideDetailsCacheModel {
+  const LocalRideDetailsCacheModel({
+    required this.version,
+    required this.rideId,
+    required this.savedAt,
+    required this.ride,
+  });
+
+  static const int currentVersion = 1;
+
+  final int version;
+  final String rideId;
+  final DateTime savedAt;
+  final LocalRideDetailsModel ride;
+
+  factory LocalRideDetailsCacheModel.create({required RidesEntity ride}) {
+    return LocalRideDetailsCacheModel(
+      version: currentVersion,
+      rideId: ride.id,
+      savedAt: DateTime.now().toUtc(),
+      ride: LocalRideDetailsModel.fromEntity(ride),
+    );
+  }
+
+  factory LocalRideDetailsCacheModel.fromJson(Map<String, dynamic> json) {
+    final version = _readRequiredInt(json['version'], 'version');
+    if (version != currentVersion) {
+      throw FormatException('Unsupported cache version: $version');
+    }
+
+    final rawRide = json['ride'];
+    if (rawRide is! Map) {
+      throw const FormatException('Invalid ride payload.');
+    }
+
+    final ride = LocalRideDetailsModel.fromJson(
+      Map<String, dynamic>.from(rawRide),
+    );
+    final rideId = _readRequiredString(json['rideId'], 'rideId');
+    if (ride.id != rideId) {
+      throw const FormatException('Stored ride cache is inconsistent.');
+    }
+
+    return LocalRideDetailsCacheModel(
+      version: version,
+      rideId: rideId,
+      savedAt: _parseRequiredDateTime(json['savedAt'], 'savedAt'),
+      ride: ride,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'version': version,
+      'rideId': rideId,
+      'savedAt': savedAt.toIso8601String(),
+      'ride': ride.toJson(),
+    };
+  }
+
+  bool matchesRide(String currentRideId) {
+    return rideId == currentRideId && ride.id == currentRideId;
+  }
+
+  bool isExpired({Duration maxAge = const Duration(hours: 6)}) {
+    final now = DateTime.now().toUtc();
+    if (savedAt.isAfter(now.add(const Duration(minutes: 5)))) {
+      return true;
+    }
+    return now.difference(savedAt.toUtc()) > maxAge;
+  }
+
+  RidesEntity toEntity() => ride.toEntity();
+}
+
+class LocalRideDetailsModel {
+  const LocalRideDetailsModel({
+    required this.id,
+    required this.driverId,
+    required this.driverName,
+    required this.driverEmail,
+    required this.origin,
+    required this.destination,
+    required this.departureAt,
+    required this.estimatedDurationMinutes,
+    required this.totalSeats,
+    required this.availableSeats,
+    required this.pricePerSeat,
+    required this.paymentOption,
+    required this.status,
+    required this.notes,
+    required this.passengerIds,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.driverRating,
+    required this.reviewCount,
+    required this.onTimeRate,
+    required this.verifiedByUniversity,
+  });
+
+  final String id;
+  final String driverId;
+  final String driverName;
+  final String driverEmail;
+  final String origin;
+  final String destination;
+  final DateTime departureAt;
+  final int estimatedDurationMinutes;
+  final int totalSeats;
+  final int availableSeats;
+  final int pricePerSeat;
+  final RidePaymentOption paymentOption;
+  final String status;
+  final String notes;
+  final List<String> passengerIds;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final double driverRating;
+  final int reviewCount;
+  final int onTimeRate;
+  final bool verifiedByUniversity;
+
+  factory LocalRideDetailsModel.fromEntity(RidesEntity entity) {
+    return LocalRideDetailsModel(
+      id: entity.id,
+      driverId: entity.driverId,
+      driverName: entity.driverName,
+      driverEmail: entity.driverEmail,
+      origin: entity.origin,
+      destination: entity.destination,
+      departureAt: entity.departureAt,
+      estimatedDurationMinutes: entity.estimatedDurationMinutes,
+      totalSeats: entity.totalSeats,
+      availableSeats: entity.availableSeats,
+      pricePerSeat: entity.pricePerSeat,
+      paymentOption: entity.paymentOption,
+      status: entity.status,
+      notes: entity.notes,
+      passengerIds: List<String>.from(entity.passengerIds),
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      driverRating: entity.driverRating,
+      reviewCount: entity.reviewCount,
+      onTimeRate: entity.onTimeRate,
+      verifiedByUniversity: entity.verifiedByUniversity,
+    );
+  }
+
+  factory LocalRideDetailsModel.fromJson(Map<String, dynamic> json) {
+    return LocalRideDetailsModel(
+      id: _readRequiredString(json['id'], 'id'),
+      driverId: _readRequiredString(json['driverId'], 'driverId'),
+      driverName: _readRequiredString(json['driverName'], 'driverName'),
+      driverEmail: _readRequiredString(json['driverEmail'], 'driverEmail'),
+      origin: _readRequiredString(json['origin'], 'origin'),
+      destination: _readRequiredString(json['destination'], 'destination'),
+      departureAt: _parseRequiredDateTime(json['departureAt'], 'departureAt'),
+      estimatedDurationMinutes: _readRequiredInt(
+        json['estimatedDurationMinutes'],
+        'estimatedDurationMinutes',
+      ),
+      totalSeats: _readRequiredInt(json['totalSeats'], 'totalSeats'),
+      availableSeats: _readRequiredInt(json['availableSeats'], 'availableSeats'),
+      pricePerSeat: _readRequiredInt(json['pricePerSeat'], 'pricePerSeat'),
+      paymentOption: ridePaymentOptionFromStorage(
+        _readRequiredString(json['paymentOption'], 'paymentOption'),
+      ),
+      status: _readRequiredString(json['status'], 'status'),
+      notes: _readRequiredString(json['notes'], 'notes'),
+      passengerIds: _readRequiredStringList(json['passengerIds'], 'passengerIds'),
+      createdAt: _parseRequiredDateTime(json['createdAt'], 'createdAt'),
+      updatedAt: _parseRequiredDateTime(json['updatedAt'], 'updatedAt'),
+      driverRating: _readRequiredDouble(json['driverRating'], 'driverRating'),
+      reviewCount: _readRequiredInt(json['reviewCount'], 'reviewCount'),
+      onTimeRate: _readRequiredInt(json['onTimeRate'], 'onTimeRate'),
+      verifiedByUniversity: _readRequiredBool(
+        json['verifiedByUniversity'],
+        'verifiedByUniversity',
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'driverId': driverId,
+      'driverName': driverName,
+      'driverEmail': driverEmail,
+      'origin': origin,
+      'destination': destination,
+      'departureAt': departureAt.toIso8601String(),
+      'estimatedDurationMinutes': estimatedDurationMinutes,
+      'totalSeats': totalSeats,
+      'availableSeats': availableSeats,
+      'pricePerSeat': pricePerSeat,
+      'paymentOption': paymentOption.storageValue,
+      'status': status,
+      'notes': notes,
+      'passengerIds': passengerIds,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
+      'driverRating': driverRating,
+      'reviewCount': reviewCount,
+      'onTimeRate': onTimeRate,
+      'verifiedByUniversity': verifiedByUniversity,
+    };
+  }
+
+  RidesEntity toEntity() {
+    return RidesEntity(
+      id: id,
+      driverId: driverId,
+      driverName: driverName,
+      driverEmail: driverEmail,
+      origin: origin,
+      destination: destination,
+      departureAt: departureAt,
+      estimatedDurationMinutes: estimatedDurationMinutes,
+      totalSeats: totalSeats,
+      availableSeats: availableSeats,
+      pricePerSeat: pricePerSeat,
+      paymentOption: paymentOption,
+      status: status,
+      notes: notes,
+      passengerIds: passengerIds,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      driverRating: driverRating,
+      reviewCount: reviewCount,
+      onTimeRate: onTimeRate,
+      verifiedByUniversity: verifiedByUniversity,
+    );
+  }
+}
+
+String _readRequiredString(Object? rawValue, String fieldName) {
+  if (rawValue is! String) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return rawValue;
+}
+
+int _readRequiredInt(Object? rawValue, String fieldName) {
+  if (rawValue is num) {
+    return rawValue.toInt();
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+double _readRequiredDouble(Object? rawValue, String fieldName) {
+  if (rawValue is num) {
+    return rawValue.toDouble();
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+bool _readRequiredBool(Object? rawValue, String fieldName) {
+  if (rawValue is bool) {
+    return rawValue;
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+DateTime _parseRequiredDateTime(Object? rawValue, String fieldName) {
+  if (rawValue is! String) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  final parsed = DateTime.tryParse(rawValue);
+  if (parsed == null) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return parsed;
+}
+
+List<String> _readRequiredStringList(Object? rawValue, String fieldName) {
+  if (rawValue is! List) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  if (rawValue.any((item) => item is! String)) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return List<String>.from(rawValue);
+}

--- a/wheels/lib/features/rides/presentation/providers/rides_providers.dart
+++ b/wheels/lib/features/rides/presentation/providers/rides_providers.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/ride_details_local_datasource.dart';
 import '../../data/datasources/rides_search_local_datasource.dart';
 import '../../data/datasources/rides_remote_datasource.dart';
 import '../../data/repositories/rides_repository_impl.dart';
@@ -17,6 +18,12 @@ final ridesSearchLocalDataSourceProvider = Provider<RidesSearchLocalDataSource>(
     return RidesSearchLocalDataSource();
   },
 );
+
+final rideDetailsLocalDataSourceProvider = Provider<RideDetailsLocalDataSource>((
+  ref,
+) {
+  return RideDetailsLocalDataSource();
+});
 
 final ridesRepositoryProvider = Provider<RidesRepository>((ref) {
   return RidesRepositoryImpl(

--- a/wheels/lib/features/rides/presentation/screens/ride_details_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/ride_details_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../features/auth/domain/entities/auth_entity.dart';
 import '../../../../features/auth/presentation/providers/auth_providers.dart';
 import '../../../../router/app_routes.dart';
 import '../../../../shared/ui/app_scaffold.dart';
@@ -11,6 +12,7 @@ import '../../../../theme/app_radius.dart';
 import '../../../../theme/app_shadows.dart';
 import '../../../../theme/app_spacing.dart';
 import '../../../../theme/app_theme_palette.dart';
+import '../../data/models/local_ride_details_cache_model.dart';
 import '../../domain/entities/rides_entity.dart';
 import '../models/ride_listing.dart';
 import '../providers/rides_providers.dart';
@@ -25,6 +27,114 @@ class RideDetailsScreen extends ConsumerStatefulWidget {
 }
 
 class _RideDetailsScreenState extends ConsumerState<RideDetailsScreen> {
+  LocalRideDetailsCacheModel? _cachedRideDetails;
+  bool _hasLoadedCachedRide = false;
+  bool _isUsingCachedFallback = false;
+  String? _lastSavedRideSignature;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCachedRideDetails();
+  }
+
+  @override
+  void didUpdateWidget(covariant RideDetailsScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.rideId == widget.rideId) {
+      return;
+    }
+
+    setState(() {
+      _cachedRideDetails = null;
+      _hasLoadedCachedRide = false;
+      _isUsingCachedFallback = false;
+      _lastSavedRideSignature = null;
+    });
+    _loadCachedRideDetails();
+  }
+
+  Future<void> _loadCachedRideDetails() async {
+    final localDataSource = ref.read(rideDetailsLocalDataSourceProvider);
+    final cache = await localDataSource.loadLatestRideDetails();
+    if (!mounted) {
+      return;
+    }
+
+    if (cache == null) {
+      setState(() {
+        _hasLoadedCachedRide = true;
+      });
+      return;
+    }
+
+    if (!cache.matchesRide(widget.rideId) || cache.isExpired()) {
+      await localDataSource.clearLatestRideDetails();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _cachedRideDetails = null;
+        _hasLoadedCachedRide = true;
+        _isUsingCachedFallback = false;
+        _lastSavedRideSignature = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _cachedRideDetails = cache;
+      _hasLoadedCachedRide = true;
+      _isUsingCachedFallback = false;
+      _lastSavedRideSignature = _rideSignature(cache.toEntity());
+    });
+  }
+
+  Future<void> _saveCachedRideDetails(RidesEntity ride) async {
+    final cache = LocalRideDetailsCacheModel.create(ride: ride);
+    final nextSignature = _rideSignature(ride);
+    if (_lastSavedRideSignature == nextSignature) {
+      return;
+    }
+
+    await ref
+        .read(rideDetailsLocalDataSourceProvider)
+        .saveLatestRideDetails(cache);
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _cachedRideDetails = cache;
+      _isUsingCachedFallback = false;
+      _lastSavedRideSignature = nextSignature;
+    });
+  }
+
+  Future<void> _clearCachedRideDetails() async {
+    await ref.read(rideDetailsLocalDataSourceProvider).clearLatestRideDetails();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _cachedRideDetails = null;
+      _isUsingCachedFallback = false;
+      _lastSavedRideSignature = null;
+    });
+  }
+
+  String _rideSignature(RidesEntity ride) {
+    return [
+      ride.id,
+      ride.updatedAt.toIso8601String(),
+      ride.availableSeats.toString(),
+      ride.status,
+      ride.passengerIds.join('|'),
+    ].join('::');
+  }
+
   @override
   Widget build(BuildContext context) {
     final role = ref.watch(currentUserRoleProvider);
@@ -35,6 +145,30 @@ class _RideDetailsScreenState extends ConsumerState<RideDetailsScreen> {
     final applyState = ref.watch(rideApplicationControllerProvider);
     final currentUser = ref.watch(authUserProvider);
     final palette = context.palette;
+    final cachedRide = _cachedRideDetails?.toEntity();
+
+    ref.listen<AsyncValue<RidesEntity?>>(rideProvider(widget.rideId), (
+      previous,
+      next,
+    ) {
+      next.whenOrNull(
+        data: (ride) async {
+          if (ride == null) {
+            await _clearCachedRideDetails();
+            return;
+          }
+          await _saveCachedRideDetails(ride);
+        },
+        error: (_, _) {
+          if (!mounted || cachedRide == null) {
+            return;
+          }
+          setState(() {
+            _isUsingCachedFallback = true;
+          });
+        },
+      );
+    });
 
     ref.listen<AsyncValue<void>>(rideApplicationControllerProvider, (
       previous,
@@ -79,164 +213,215 @@ class _RideDetailsScreenState extends ConsumerState<RideDetailsScreen> {
             return const Center(child: Text('Ride not found'));
           }
 
-          final passengerApplication = applicationAsync.valueOrNull;
-          final isOwnRide = currentUser?.uid == ride.driverId;
-          final hasApplied = passengerApplication != null;
-          final canApply =
-              !isOwnRide &&
-              ride.isOpen &&
-              ride.hasAvailableSeats &&
-              !hasApplied &&
-              currentUser != null;
-          final canOpenPayment = hasApplied && !isOwnRide;
+          return _buildRideContent(
+            ride: ride,
+            palette: palette,
+            currentUser: currentUser,
+            applicationAsync: applicationAsync,
+            applyState: applyState,
+          );
+        },
+        loading: () {
+          if (!_hasLoadedCachedRide) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (cachedRide == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
 
-          return ListView(
+          return _buildRideContent(
+            ride: cachedRide,
+            palette: palette,
+            currentUser: currentUser,
+            applicationAsync: applicationAsync,
+            applyState: applyState,
+            showCachedNotice: true,
+            cachedNoticeTitle: 'Showing saved ride details',
+            cachedNoticeMessage:
+                'We loaded the latest saved ride while refreshing live availability.',
+          );
+        },
+        error: (error, _) {
+          if (cachedRide != null) {
+            return _buildRideContent(
+              ride: cachedRide,
+              palette: palette,
+              currentUser: currentUser,
+              applicationAsync: applicationAsync,
+              applyState: applyState,
+              showCachedNotice: true,
+              cachedNoticeTitle: 'Offline fallback in use',
+              cachedNoticeMessage:
+                  'Live ride data is unavailable right now. You are seeing the latest saved version.',
+            );
+          }
+
+          return Center(
+            child: Text(error.toString(), textAlign: TextAlign.center),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildRideContent({
+    required RidesEntity ride,
+    required AppThemePalette palette,
+    required AuthEntity? currentUser,
+    required AsyncValue<RideApplicationEntity?> applicationAsync,
+    required AsyncValue<void> applyState,
+    bool showCachedNotice = false,
+    String? cachedNoticeTitle,
+    String? cachedNoticeMessage,
+  }) {
+    final passengerApplication = applicationAsync.valueOrNull;
+    final isOwnRide = currentUser?.uid == ride.driverId;
+    final hasApplied = passengerApplication != null;
+    final canApply =
+        !isOwnRide &&
+        ride.isOpen &&
+        ride.hasAvailableSeats &&
+        !hasApplied &&
+        currentUser != null &&
+        !showCachedNotice;
+    final canOpenPayment = hasApplied && !isOwnRide;
+
+    return ListView(
+      children: [
+        if (showCachedNotice) ...[
+          _cachedRideNotice(
+            title: cachedNoticeTitle ?? 'Saved ride details',
+            message: cachedNoticeMessage ?? 'You are seeing locally saved data.',
+          ),
+          const SizedBox(height: AppSpacing.m),
+        ],
+        Container(
+          padding: const EdgeInsets.all(AppSpacing.m),
+          decoration: BoxDecoration(
+            color: palette.card,
+            borderRadius: BorderRadius.circular(AppRadius.sm),
+            boxShadow: AppShadows.sm,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                padding: const EdgeInsets.all(AppSpacing.m),
-                decoration: BoxDecoration(
-                  color: palette.card,
-                  borderRadius: BorderRadius.circular(AppRadius.sm),
-                  boxShadow: AppShadows.sm,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        CircleAvatar(
-                          backgroundColor: palette.primary,
-                          child: Text(
-                            ride.driverInitials,
-                            style: TextStyle(color: palette.primaryForeground),
-                          ),
-                        ),
-                        const SizedBox(width: AppSpacing.s),
-                        Expanded(
-                          child: Text(
-                            ride.driverName,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.w700,
-                              fontSize: 18,
-                            ),
-                          ),
-                        ),
-                        Text(
-                          ride.priceLabel,
-                          style: TextStyle(
-                            color: palette.primary,
-                            fontSize: 24,
-                            fontWeight: FontWeight.w800,
-                          ),
-                        ),
-                      ],
+              Row(
+                children: [
+                  CircleAvatar(
+                    backgroundColor: palette.primary,
+                    child: Text(
+                      ride.driverInitials,
+                      style: TextStyle(color: palette.primaryForeground),
                     ),
-                    const SizedBox(height: AppSpacing.m),
-                    _DetailRow(Icons.trip_origin, 'Origin', ride.origin),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.place_outlined,
-                      'Destination',
-                      ride.destination,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.calendar_month_outlined,
-                      'Date',
-                      ride.dateLabel,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.schedule_outlined,
-                      'Departure',
-                      ride.departureLabel,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.timer_outlined,
-                      'Duration',
-                      ride.durationLabel,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.event_seat_outlined,
-                      'Seats left',
-                      '${ride.availableSeats} of ${ride.totalSeats}',
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      ride.acceptsCardPayments
-                          ? Icons.credit_card_outlined
-                          : Icons.account_balance_outlined,
-                      'Payment',
-                      ride.paymentOptionLabel,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    _DetailRow(
-                      Icons.info_outline,
-                      'Status',
-                      _statusLabel(ride.status),
-                    ),
-                    if (ride.notes.trim().isNotEmpty) ...[
-                      const SizedBox(height: AppSpacing.s),
-                      _DetailRow(Icons.notes_outlined, 'Notes', ride.notes),
-                    ],
-                  ],
-                ),
-              ),
-              if (ride.acceptsCardPayments) ...[
-                const SizedBox(height: AppSpacing.m),
-                _CardPayoutEstimateCard(ride: ride),
-              ],
-              const SizedBox(height: AppSpacing.m),
-              if (isOwnRide)
-                _messageCard(
-                  'This is your ride',
-                  'Passengers can already see it in the search list and apply from there.',
-                )
-              else if (hasApplied)
-                _messageCard(
-                  'Application sent',
-                  'You already applied to this ride. We will keep this seat linked to your account.',
-                )
-              else if (!ride.hasAvailableSeats)
-                _messageCard(
-                  'Ride is full',
-                  'All seats have already been taken for this trip.',
-                )
-              else if (!ride.isOpen)
-                _messageCard(
-                  'Ride unavailable',
-                  'This ride is no longer open for new passengers.',
-                ),
-              const SizedBox(height: AppSpacing.s),
-              ElevatedButton(
-                onPressed: canApply && !applyState.isLoading
-                    ? () async {
-                        await ref
-                            .read(rideApplicationControllerProvider.notifier)
-                            .applyToRide(
-                              rideId: ride.id,
-                              passengerId: currentUser.uid,
-                              passengerName: currentUser.fullName,
-                              passengerEmail: currentUser.email,
-                            );
-                      }
-                    : canOpenPayment
-                    ? () => context.go(AppRoutes.paymentByRideId(ride.id))
-                    : null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: palette.accent,
-                  foregroundColor: palette.accentForeground,
-                  disabledBackgroundColor: palette.surfaceMuted,
-                  disabledForegroundColor: palette.textSecondary,
-                  minimumSize: const Size(double.infinity, 50),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(AppRadius.sm),
                   ),
-                ),
-                child: Text(
-                  _actionLabel(
+                  const SizedBox(width: AppSpacing.s),
+                  Expanded(
+                    child: Text(
+                      ride.driverName,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w700,
+                        fontSize: 18,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    ride.priceLabel,
+                    style: TextStyle(
+                      color: palette.primary,
+                      fontSize: 24,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.m),
+              _DetailRow(Icons.trip_origin, 'Origin', ride.origin),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.place_outlined, 'Destination', ride.destination),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.calendar_month_outlined, 'Date', ride.dateLabel),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.schedule_outlined, 'Departure', ride.departureLabel),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.timer_outlined, 'Duration', ride.durationLabel),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(
+                Icons.event_seat_outlined,
+                'Seats left',
+                '${ride.availableSeats} of ${ride.totalSeats}',
+              ),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(
+                ride.acceptsCardPayments
+                    ? Icons.credit_card_outlined
+                    : Icons.account_balance_outlined,
+                'Payment',
+                ride.paymentOptionLabel,
+              ),
+              const SizedBox(height: AppSpacing.s),
+              _DetailRow(Icons.info_outline, 'Status', _statusLabel(ride.status)),
+              if (ride.notes.trim().isNotEmpty) ...[
+                const SizedBox(height: AppSpacing.s),
+                _DetailRow(Icons.notes_outlined, 'Notes', ride.notes),
+              ],
+            ],
+          ),
+        ),
+        if (ride.acceptsCardPayments) ...[
+          const SizedBox(height: AppSpacing.m),
+          _CardPayoutEstimateCard(ride: ride),
+        ],
+        const SizedBox(height: AppSpacing.m),
+        if (isOwnRide)
+          _messageCard(
+            'This is your ride',
+            'Passengers can already see it in the search list and apply from there.',
+          )
+        else if (hasApplied)
+          _messageCard(
+            'Application sent',
+            'You already applied to this ride. We will keep this seat linked to your account.',
+          )
+        else if (!ride.hasAvailableSeats)
+          _messageCard(
+            'Ride is full',
+            'All seats have already been taken for this trip.',
+          )
+        else if (!ride.isOpen)
+          _messageCard(
+            'Ride unavailable',
+            'This ride is no longer open for new passengers.',
+          ),
+        const SizedBox(height: AppSpacing.s),
+        ElevatedButton(
+          onPressed: canApply && !applyState.isLoading
+              ? () async {
+                  await ref
+                      .read(rideApplicationControllerProvider.notifier)
+                      .applyToRide(
+                        rideId: ride.id,
+                        passengerId: currentUser.uid,
+                        passengerName: currentUser.fullName,
+                        passengerEmail: currentUser.email,
+                      );
+                }
+              : canOpenPayment && !showCachedNotice
+              ? () => context.go(AppRoutes.paymentByRideId(ride.id))
+              : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: palette.accent,
+            foregroundColor: palette.accentForeground,
+            disabledBackgroundColor: palette.surfaceMuted,
+            disabledForegroundColor: palette.textSecondary,
+            minimumSize: const Size(double.infinity, 50),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadius.sm),
+            ),
+          ),
+          child: Text(
+            showCachedNotice
+                ? 'Waiting for live ride details'
+                : _actionLabel(
                     isOwnRide: isOwnRide,
                     hasApplied: hasApplied,
                     passengerApplication: passengerApplication,
@@ -245,16 +430,82 @@ class _RideDetailsScreenState extends ConsumerState<RideDetailsScreen> {
                     hasAvailableSeats: ride.hasAvailableSeats,
                     isLoading: applyState.isLoading,
                   ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _cachedRideNotice({
+    required String title,
+    required String message,
+  }) {
+    final palette = context.palette;
+    final savedAtLabel = _cachedRideDetails == null
+        ? null
+        : 'Saved ${_formatSavedAt(_cachedRideDetails!.savedAt)}';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: palette.secondary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        border: Border.all(color: palette.secondary.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            _isUsingCachedFallback
+                ? Icons.cloud_off_outlined
+                : Icons.offline_bolt_outlined,
+            color: palette.secondary,
+          ),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-            ],
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, _) =>
-            Center(child: Text(error.toString(), textAlign: TextAlign.center)),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  message,
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w600,
+                    height: 1.35,
+                  ),
+                ),
+                if (savedAtLabel != null) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    savedAtLabel,
+                    style: TextStyle(color: palette.textSecondary),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
       ),
     );
+  }
+
+  String _formatSavedAt(DateTime savedAt) {
+    final local = savedAt.toLocal();
+    final day = local.day.toString().padLeft(2, '0');
+    final month = local.month.toString().padLeft(2, '0');
+    final year = local.year.toString();
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
+    return 'on $day/$month/$year at $hour:$minute';
   }
 
   String _statusLabel(String status) {

--- a/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../features/auth/presentation/providers/auth_providers.dart';
 import '../../../../router/app_routes.dart';
+import '../../../../shared/providers/connectivity_provider.dart';
 import '../../../../shared/services/current_location_service.dart';
 import '../../../../shared/ui/app_scaffold.dart';
 import '../../../../shared/widgets/app_bottom_nav.dart';
@@ -56,6 +57,8 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   String _appliedDestinationQuery = '';
   LocalRideSearchCacheModel? _cachedSearchCache;
   String? _lastSavedCacheSignature;
+  bool _isShowingOfflineFallback = false;
+  bool _isRetryingSearch = false;
 
   @override
   void initState() {
@@ -97,7 +100,21 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
 
   Future<void> _initializeSearchState() async {
     await _restoreLatestSearch();
+    await _syncOfflineFallbackWithConnectivity();
     await _prefillOriginWithCurrentLocation();
+  }
+
+  Future<void> _syncOfflineFallbackWithConnectivity() async {
+    final isOnline = await ref
+        .read(connectivityServiceProvider)
+        .hasConnection();
+    if (!mounted || isOnline || _cachedSearchCache == null) {
+      return;
+    }
+
+    setState(() {
+      _isShowingOfflineFallback = true;
+    });
   }
 
   Future<void> _restoreLatestSearch() async {
@@ -311,6 +328,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
       _appliedDestinationQuery = '';
       _cachedSearchCache = null;
       _lastSavedCacheSignature = null;
+      _isShowingOfflineFallback = false;
     });
 
     await _ridesSearchLocalDataSource.clearLatestSearch();
@@ -401,6 +419,18 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   }
 
   Future<void> _applySearch() async {
+    final isOnline = await ref
+        .read(connectivityServiceProvider)
+        .hasConnection();
+    if (!isOnline) {
+      await _showOfflineFallback();
+      return;
+    }
+
+    await _runLiveSearch();
+  }
+
+  Future<void> _runLiveSearch({bool refreshProvider = false}) async {
     final nextOriginQuery = _originController.text.trim();
     final nextDestinationQuery = _destinationController.text.trim();
     final selectedDate = _dateOnly(_selectedDate);
@@ -418,6 +448,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
       _appliedOriginQuery = nextOriginQuery.toLowerCase();
       _appliedDestinationQuery = nextDestinationQuery.toLowerCase();
       _appliedDate = selectedDate;
+      _isShowingOfflineFallback = false;
     });
 
     unawaited(
@@ -430,10 +461,74 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
       ),
     );
 
+    if (refreshProvider) {
+      ref.invalidate(availableRidesProvider);
+    }
+
     final ridesAsync = ref.read(availableRidesProvider);
     final rides = ridesAsync.valueOrNull;
     if (rides != null) {
       await _persistLatestSuccessfulSearch(_applyFilters(rides));
+    }
+  }
+
+  Future<void> _showOfflineFallback() async {
+    await _restoreLatestSearch();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _isShowingOfflineFallback = true;
+    });
+
+    final hasCachedResults = _cachedSearchCache != null;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          hasCachedResults
+              ? 'You are offline. Showing your latest saved ride search.'
+              : 'You are offline and there is no saved ride search on this device yet.',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _retrySearch() async {
+    if (_isRetryingSearch) {
+      return;
+    }
+
+    setState(() {
+      _isRetryingSearch = true;
+    });
+
+    try {
+      final isOnline = await ref
+          .read(connectivityServiceProvider)
+          .hasConnection();
+      if (!mounted) {
+        return;
+      }
+
+      if (!isOnline) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Connection is still unavailable. Try again once you are back online.',
+            ),
+          ),
+        );
+        return;
+      }
+
+      await _runLiveSearch(refreshProvider: true);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isRetryingSearch = false;
+        });
+      }
     }
   }
 
@@ -482,11 +577,12 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   Widget _buildResultsSection(
     List<RidesEntity> results, {
     bool isCached = false,
+    required bool isOnline,
   }) {
     return Column(
       children: [
         if (isCached) ...[
-          _cachedResultsNotice(),
+          _cachedResultsNotice(isOnline: isOnline),
           const SizedBox(height: AppSpacing.m),
         ],
         _sectionTitle('Available Drivers', '${results.length} rides'),
@@ -505,8 +601,24 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     );
   }
 
-  Widget _cachedResultsNotice() {
+  String _formatCacheSavedAt(DateTime value) {
+    final localValue = value.toLocal();
+    final day = localValue.day.toString().padLeft(2, '0');
+    final month = localValue.month.toString().padLeft(2, '0');
+    final hour = localValue.hour.toString().padLeft(2, '0');
+    final minute = localValue.minute.toString().padLeft(2, '0');
+    return '$day/$month/${localValue.year} $hour:$minute';
+  }
+
+  Widget _cachedResultsNotice({required bool isOnline}) {
     final palette = context.palette;
+    final savedAt = _cachedSearchCache?.savedAt;
+    final title = isOnline
+        ? 'Connection restored. You are still viewing cached results.'
+        : 'You are offline. Showing the latest saved results.';
+    final description = savedAt == null
+        ? 'Refresh when a connection is available to get live rides again.'
+        : 'Last saved on ${_formatCacheSavedAt(savedAt)}. Refresh when a connection is available to get live rides again.';
 
     return Container(
       width: double.infinity,
@@ -522,14 +634,104 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
           Icon(Icons.offline_bolt_outlined, color: palette.secondary),
           const SizedBox(width: AppSpacing.s),
           Expanded(
-            child: Text(
-              'Showing the latest saved search results while live data is unavailable.',
-              style: TextStyle(
-                color: palette.textPrimary,
-                fontWeight: FontWeight.w600,
-                height: 1.35,
-              ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w700,
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  description,
+                  style: TextStyle(
+                    color: palette.textSecondary,
+                    fontWeight: FontWeight.w600,
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.s),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: OutlinedButton.icon(
+                    onPressed: isOnline && !_isRetryingSearch
+                        ? _retrySearch
+                        : null,
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: palette.secondary,
+                      side: BorderSide(
+                        color: palette.secondary.withValues(alpha: 0.35),
+                      ),
+                    ),
+                    icon: _isRetryingSearch
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.refresh),
+                    label: Text(
+                      isOnline ? 'Refresh results' : 'Reconnect to refresh',
+                    ),
+                  ),
+                ),
+              ],
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _offlineEmptyState({required bool isOnline}) {
+    final palette = context.palette;
+
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.l),
+      decoration: BoxDecoration(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        boxShadow: AppShadows.sm,
+      ),
+      child: Column(
+        children: [
+          Icon(Icons.cloud_off_outlined, size: 64, color: palette.secondary),
+          const SizedBox(height: AppSpacing.s),
+          Text(
+            'No offline results available',
+            style: TextStyle(
+              fontWeight: FontWeight.w700,
+              fontSize: 18,
+              color: palette.textPrimary,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            isOnline
+                ? 'Connection is back. Retry to load live rides.'
+                : 'This device does not have a saved ride search yet. Connect to the internet and retry.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: palette.textSecondary, height: 1.35),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          OutlinedButton.icon(
+            onPressed: isOnline && !_isRetryingSearch ? _retrySearch : null,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: palette.primary,
+              side: BorderSide(color: palette.border),
+            ),
+            icon: _isRetryingSearch
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.refresh),
+            label: const Text('Retry'),
           ),
         ],
       ),
@@ -541,6 +743,51 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     final palette = context.palette;
     final role = ref.watch(currentUserRoleProvider);
     final ridesAsync = ref.watch(availableRidesProvider);
+    final connectivityAsync = ref.watch(connectivityStatusProvider);
+    final isOnline = connectivityAsync.valueOrNull ?? true;
+    final cachedResults = _cachedSearchCache?.toEntities();
+
+    ref.listen<AsyncValue<bool>>(connectivityStatusProvider, (_, next) {
+      next.whenData((hasConnection) {
+        if (!mounted || hasConnection || _cachedSearchCache == null) {
+          return;
+        }
+
+        if (_isShowingOfflineFallback) {
+          return;
+        }
+
+        setState(() {
+          _isShowingOfflineFallback = true;
+        });
+      });
+    });
+
+    final shouldShowCachedResults =
+        cachedResults != null && (_isShowingOfflineFallback || !isOnline);
+    final shouldShowOfflineEmptyState =
+        cachedResults == null && (_isShowingOfflineFallback || !isOnline);
+
+    final resultsSection = shouldShowCachedResults
+        ? _buildResultsSection(
+            cachedResults,
+            isCached: true,
+            isOnline: isOnline,
+          )
+        : shouldShowOfflineEmptyState
+        ? _offlineEmptyState(isOnline: isOnline)
+        : ridesAsync.when(
+            data: (rides) {
+              final results = _applyFilters(rides);
+              unawaited(_persistLatestSuccessfulSearch(results));
+              return _buildResultsSection(results, isOnline: isOnline);
+            },
+            loading: () => const Padding(
+              padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (error, _) => _loadError(error, isOnline: isOnline),
+          );
 
     return AppScaffold(
       title: 'Rides',
@@ -562,24 +809,15 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
           children: [
             _searchCard(),
             const SizedBox(height: AppSpacing.m),
-            _sortBar(),
+            _sortBar(
+              isInteractionDisabled: _isShowingOfflineFallback || !isOnline,
+            ),
             if (_sort == RideSortOption.smartMatch) ...[
               const SizedBox(height: AppSpacing.m),
               _smartMatchNotice(),
             ],
             const SizedBox(height: AppSpacing.l),
-            ridesAsync.when(
-              data: (rides) {
-                final results = _applyFilters(rides);
-                unawaited(_persistLatestSuccessfulSearch(results));
-                return _buildResultsSection(results);
-              },
-              loading: () => const Padding(
-                padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
-                child: Center(child: CircularProgressIndicator()),
-              ),
-              error: (error, _) => _loadError(error),
-            ),
+            resultsSection,
             const SizedBox(height: AppSpacing.s),
           ],
         ),
@@ -716,7 +954,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     );
   }
 
-  Widget _sortBar() {
+  Widget _sortBar({bool isInteractionDisabled = false}) {
     final palette = context.palette;
 
     return Row(
@@ -761,11 +999,13 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
                           : palette.primary,
                       fontWeight: FontWeight.w600,
                     ),
-                    onSelected: (_) {
-                      setState(() {
-                        _sort = option;
-                      });
-                    },
+                    onSelected: isInteractionDisabled
+                        ? null
+                        : (_) {
+                            setState(() {
+                              _sort = option;
+                            });
+                          },
                   ),
                 );
               }).toList(),
@@ -876,10 +1116,26 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     );
   }
 
-  Widget _loadError(Object error) {
+  Widget _loadError(Object error, {required bool isOnline}) {
     final cachedResults = _cachedSearchCache?.toEntities();
-    if (cachedResults != null) {
-      return _buildResultsSection(cachedResults, isCached: true);
+    if (cachedResults != null && !isOnline) {
+      if (!_isShowingOfflineFallback) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) {
+            return;
+          }
+
+          setState(() {
+            _isShowingOfflineFallback = true;
+          });
+        });
+      }
+
+      return _buildResultsSection(
+        cachedResults,
+        isCached: true,
+        isOnline: isOnline,
+      );
     }
 
     final palette = context.palette;
@@ -905,9 +1161,27 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
           ),
           const SizedBox(height: AppSpacing.xs),
           Text(
-            error.toString(),
+            isOnline
+                ? error.toString()
+                : 'Your connection is unavailable and there are no cached results to show yet.',
             textAlign: TextAlign.center,
             style: TextStyle(color: palette.textSecondary),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          OutlinedButton.icon(
+            onPressed: isOnline && !_isRetryingSearch ? _retrySearch : null,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: palette.primary,
+              side: BorderSide(color: palette.border),
+            ),
+            icon: _isRetryingSearch
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.refresh),
+            label: const Text('Retry'),
           ),
         ],
       ),

--- a/wheels/lib/shared/providers/connectivity_provider.dart
+++ b/wheels/lib/shared/providers/connectivity_provider.dart
@@ -1,0 +1,29 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ConnectivityService {
+  const ConnectivityService();
+
+  Future<bool> hasConnection() async {
+    final results = await Connectivity().checkConnectivity();
+    return _isConnected(results);
+  }
+
+  Stream<bool> watchConnection() {
+    return Connectivity().onConnectivityChanged.map(_isConnected).distinct();
+  }
+
+  bool _isConnected(List<ConnectivityResult> results) {
+    return results.any((result) => result != ConnectivityResult.none);
+  }
+}
+
+final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
+  return const ConnectivityService();
+});
+
+final connectivityStatusProvider = StreamProvider<bool>((ref) async* {
+  final service = ref.watch(connectivityServiceProvider);
+  yield await service.hasConnection();
+  yield* service.watchConnection();
+});

--- a/wheels/pubspec.lock
+++ b/wheels/pubspec.lock
@@ -113,6 +113,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   crypto:
     dependency: transitive
     description:
@@ -532,10 +548,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -552,6 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   package_info_plus:
     dependency: transitive
     description:
@@ -745,10 +769,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/wheels/pubspec.yaml
+++ b/wheels/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   firebase_messaging: ^16.0.2
   fl_chart: ^0.70.2
   shared_preferences: ^2.5.3
+  connectivity_plus: ^7.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**PR Description**

Implements eventual connectivity safeguards in `RideDetailsScreen` for actions that depend on fresh backend state.

This change keeps the cached ride details experience for read-only access, but prevents users from performing critical actions such as joining a ride or continuing to payment-related flows when the app is offline or when the screen is showing cached fallback data. The goal is to avoid unsafe decisions based on stale local state.

**What changed**
- Added live connectivity awareness to `RideDetailsScreen` using the existing connectivity provider
- Blocked critical actions when the device is offline
- Blocked critical actions when ride details are being shown from cached fallback data
- Added clear UI messaging explaining why the action is unavailable
- Updated the main action button label to reflect connectivity/state conditions
- Added automatic user feedback when connection is lost or restored
- Automatically re-enabled actions once connectivity returns and live ride data is available again

**Behavior**
- Cached ride details can still be displayed offline for continuity
- Cached ride data is no longer treated as authoritative for write/payment-sensitive actions
- Applying to a ride now requires live backend validation
- Payment-related navigation from ride details now requires live backend validation

**Why**
This follows a hybrid approach:
- `offline-first` for read access to cached ride details
- `online-first` for critical actions that require fresh backend validation

This prevents inconsistent flows such as applying to a ride with outdated seat availability or proceeding with payment-related actions from stale ride state.