### PR TITLE
Implemented create ride offline draft

### DIFF
--- a/wheels/lib/features/rides/data/datasources/create_ride_draft_local_datasource.dart
+++ b/wheels/lib/features/rides/data/datasources/create_ride_draft_local_datasource.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../../../../shared/storage/app_hive.dart';
+import '../models/local_create_ride_draft_model.dart';
+
+LocalCreateRideDraftModel _decodeCreateRideDraft(String raw) {
+  final decoded = jsonDecode(raw);
+  if (decoded is! Map) {
+    throw const FormatException('Stored create ride draft is invalid.');
+  }
+
+  return LocalCreateRideDraftModel.fromJson(Map<String, dynamic>.from(decoded));
+}
+
+String _encodeCreateRideDraft(LocalCreateRideDraftModel draft) {
+  return jsonEncode(draft.toJson());
+}
+
+class CreateRideDraftLocalDataSource {
+  static const String _draftKeyPrefix = 'create_ride_draft';
+
+  Future<LocalCreateRideDraftModel?> loadDraft({required String cacheId}) async {
+    final box = Hive.box<String>(AppHiveBoxes.createRideDrafts);
+    final rawDraft = box.get(_buildKey(cacheId));
+    if (rawDraft == null || rawDraft.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      return await compute(_decodeCreateRideDraft, rawDraft);
+    } catch (_) {
+      await clearDraft(cacheId: cacheId);
+      return null;
+    }
+  }
+
+  Future<void> saveDraft({
+    required String cacheId,
+    required LocalCreateRideDraftModel draft,
+  }) async {
+    final encoded = await compute(_encodeCreateRideDraft, draft);
+    final box = Hive.box<String>(AppHiveBoxes.createRideDrafts);
+    await box.put(_buildKey(cacheId), encoded);
+  }
+
+  Future<void> clearDraft({required String cacheId}) async {
+    final box = Hive.box<String>(AppHiveBoxes.createRideDrafts);
+    await box.delete(_buildKey(cacheId));
+  }
+
+  String _buildKey(String cacheId) {
+    return '$_draftKeyPrefix:$cacheId';
+  }
+}

--- a/wheels/lib/features/rides/data/models/local_create_ride_draft_model.dart
+++ b/wheels/lib/features/rides/data/models/local_create_ride_draft_model.dart
@@ -1,0 +1,235 @@
+import '../../domain/entities/rides_entity.dart';
+
+class LocalCreateRideDraftModel {
+  const LocalCreateRideDraftModel({
+    required this.version,
+    required this.savedAt,
+    required this.origin,
+    required this.destination,
+    required this.notes,
+    required this.dateText,
+    required this.timeText,
+    required this.durationText,
+    required this.priceText,
+    required this.availableSeats,
+    required this.paymentOption,
+    required this.currentLocationSuggestion,
+    required this.pendingSync,
+    required this.pendingSyncReason,
+    required this.pendingSyncRequestedAt,
+  });
+
+  static const int currentVersion = 1;
+
+  final int version;
+  final DateTime savedAt;
+  final String origin;
+  final String destination;
+  final String notes;
+  final String dateText;
+  final String timeText;
+  final String durationText;
+  final String priceText;
+  final int availableSeats;
+  final RidePaymentOption paymentOption;
+  final String? currentLocationSuggestion;
+  final bool pendingSync;
+  final String? pendingSyncReason;
+  final DateTime? pendingSyncRequestedAt;
+
+  factory LocalCreateRideDraftModel.create({
+    required String origin,
+    required String destination,
+    required String notes,
+    required String dateText,
+    required String timeText,
+    required String durationText,
+    required String priceText,
+    required int availableSeats,
+    required RidePaymentOption paymentOption,
+    String? currentLocationSuggestion,
+    bool pendingSync = false,
+    String? pendingSyncReason,
+    DateTime? pendingSyncRequestedAt,
+  }) {
+    return LocalCreateRideDraftModel(
+      version: currentVersion,
+      savedAt: DateTime.now().toUtc(),
+      origin: origin,
+      destination: destination,
+      notes: notes,
+      dateText: dateText,
+      timeText: timeText,
+      durationText: durationText,
+      priceText: priceText,
+      availableSeats: availableSeats,
+      paymentOption: paymentOption,
+      currentLocationSuggestion: currentLocationSuggestion,
+      pendingSync: pendingSync,
+      pendingSyncReason: pendingSyncReason,
+      pendingSyncRequestedAt: pendingSyncRequestedAt?.toUtc(),
+    );
+  }
+
+  factory LocalCreateRideDraftModel.fromJson(Map<String, dynamic> json) {
+    final version = _readRequiredInt(json['version'], 'version');
+    if (version != currentVersion) {
+      throw FormatException('Unsupported create ride draft version: $version');
+    }
+
+    return LocalCreateRideDraftModel(
+      version: version,
+      savedAt: _parseRequiredDateTime(json['savedAt'], 'savedAt'),
+      origin: _readRequiredString(json['origin'], 'origin'),
+      destination: _readRequiredString(json['destination'], 'destination'),
+      notes: _readRequiredString(json['notes'], 'notes'),
+      dateText: _readRequiredString(json['dateText'], 'dateText'),
+      timeText: _readRequiredString(json['timeText'], 'timeText'),
+      durationText: _readRequiredString(json['durationText'], 'durationText'),
+      priceText: _readRequiredString(json['priceText'], 'priceText'),
+      availableSeats: _readRequiredInt(json['availableSeats'], 'availableSeats'),
+      paymentOption: ridePaymentOptionFromStorage(
+        _readRequiredString(json['paymentOption'], 'paymentOption'),
+      ),
+      currentLocationSuggestion: _readOptionalString(
+        json['currentLocationSuggestion'],
+      ),
+      pendingSync: _readRequiredBool(json['pendingSync'], 'pendingSync'),
+      pendingSyncReason: _readOptionalString(json['pendingSyncReason']),
+      pendingSyncRequestedAt: _parseOptionalDateTime(
+        json['pendingSyncRequestedAt'],
+        'pendingSyncRequestedAt',
+      ),
+    );
+  }
+
+  bool get hasMeaningfulData {
+    return origin.trim().isNotEmpty ||
+        destination.trim().isNotEmpty ||
+        notes.trim().isNotEmpty ||
+        dateText.trim().isNotEmpty ||
+        timeText.trim().isNotEmpty ||
+        durationText.trim().isNotEmpty ||
+        priceText.trim().isNotEmpty;
+  }
+
+  LocalCreateRideDraftModel copyWith({
+    DateTime? savedAt,
+    String? origin,
+    String? destination,
+    String? notes,
+    String? dateText,
+    String? timeText,
+    String? durationText,
+    String? priceText,
+    int? availableSeats,
+    RidePaymentOption? paymentOption,
+    String? currentLocationSuggestion,
+    bool? pendingSync,
+    String? pendingSyncReason,
+    DateTime? pendingSyncRequestedAt,
+    bool clearPendingSyncReason = false,
+    bool clearPendingSyncRequestedAt = false,
+  }) {
+    return LocalCreateRideDraftModel(
+      version: version,
+      savedAt: savedAt ?? this.savedAt,
+      origin: origin ?? this.origin,
+      destination: destination ?? this.destination,
+      notes: notes ?? this.notes,
+      dateText: dateText ?? this.dateText,
+      timeText: timeText ?? this.timeText,
+      durationText: durationText ?? this.durationText,
+      priceText: priceText ?? this.priceText,
+      availableSeats: availableSeats ?? this.availableSeats,
+      paymentOption: paymentOption ?? this.paymentOption,
+      currentLocationSuggestion:
+          currentLocationSuggestion ?? this.currentLocationSuggestion,
+      pendingSync: pendingSync ?? this.pendingSync,
+      pendingSyncReason: clearPendingSyncReason
+          ? null
+          : (pendingSyncReason ?? this.pendingSyncReason),
+      pendingSyncRequestedAt: clearPendingSyncRequestedAt
+          ? null
+          : (pendingSyncRequestedAt ?? this.pendingSyncRequestedAt),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'version': version,
+      'savedAt': savedAt.toIso8601String(),
+      'origin': origin,
+      'destination': destination,
+      'notes': notes,
+      'dateText': dateText,
+      'timeText': timeText,
+      'durationText': durationText,
+      'priceText': priceText,
+      'availableSeats': availableSeats,
+      'paymentOption': paymentOption.storageValue,
+      'currentLocationSuggestion': currentLocationSuggestion,
+      'pendingSync': pendingSync,
+      'pendingSyncReason': pendingSyncReason,
+      'pendingSyncRequestedAt': pendingSyncRequestedAt?.toIso8601String(),
+    };
+  }
+}
+
+String _readRequiredString(Object? rawValue, String fieldName) {
+  if (rawValue is! String) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return rawValue;
+}
+
+String? _readOptionalString(Object? rawValue) {
+  if (rawValue == null) {
+    return null;
+  }
+  if (rawValue is! String) {
+    throw const FormatException('Invalid optional string value.');
+  }
+  return rawValue;
+}
+
+int _readRequiredInt(Object? rawValue, String fieldName) {
+  if (rawValue is num) {
+    return rawValue.toInt();
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+bool _readRequiredBool(Object? rawValue, String fieldName) {
+  if (rawValue is bool) {
+    return rawValue;
+  }
+
+  throw FormatException('Invalid $fieldName value.');
+}
+
+DateTime _parseRequiredDateTime(Object? rawValue, String fieldName) {
+  final rawString = _readRequiredString(rawValue, fieldName);
+  final parsed = DateTime.tryParse(rawString);
+  if (parsed == null) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return parsed.toUtc();
+}
+
+DateTime? _parseOptionalDateTime(Object? rawValue, String fieldName) {
+  final rawString = _readOptionalString(rawValue);
+  if (rawString == null || rawString.trim().isEmpty) {
+    return null;
+  }
+
+  final parsed = DateTime.tryParse(rawString);
+  if (parsed == null) {
+    throw FormatException('Invalid $fieldName value.');
+  }
+
+  return parsed.toUtc();
+}

--- a/wheels/lib/features/rides/presentation/providers/rides_providers.dart
+++ b/wheels/lib/features/rides/presentation/providers/rides_providers.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../shared/cache/memory_lru_cache.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/create_ride_draft_local_datasource.dart';
 import '../../data/datasources/ride_details_local_datasource.dart';
 import '../../data/datasources/rides_search_local_datasource.dart';
 import '../../data/models/local_ride_details_cache_model.dart';
@@ -32,6 +33,11 @@ final rideDetailsLocalDataSourceProvider = Provider<RideDetailsLocalDataSource>(
 final rideDetailsMemoryCacheProvider =
     Provider<MemoryLruCache<String, LocalRideDetailsCacheModel>>((ref) {
       return MemoryLruCache<String, LocalRideDetailsCacheModel>(maxEntries: 8);
+    });
+
+final createRideDraftLocalDataSourceProvider =
+    Provider<CreateRideDraftLocalDataSource>((ref) {
+      return CreateRideDraftLocalDataSource();
     });
 
 final ridesRepositoryProvider = Provider<RidesRepository>((ref) {

--- a/wheels/lib/features/rides/presentation/screens/create_ride_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/create_ride_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -5,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../features/auth/presentation/providers/auth_providers.dart';
 import '../../../../router/app_routes.dart';
+import '../../../../shared/providers/connectivity_provider.dart';
 import '../../../../shared/services/current_location_service.dart';
 import '../../../../shared/ui/app_scaffold.dart';
 import '../../../../shared/utils/app_formatter.dart';
@@ -14,6 +17,7 @@ import '../../../../theme/app_radius.dart';
 import '../../../../theme/app_shadows.dart';
 import '../../../../theme/app_spacing.dart';
 import '../../../../theme/app_theme_palette.dart';
+import '../../data/models/local_create_ride_draft_model.dart';
 import '../../domain/entities/rides_entity.dart';
 import '../providers/rides_providers.dart';
 
@@ -33,6 +37,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
   final _timeController = TextEditingController();
   final _durationController = TextEditingController(text: '30');
   final _priceController = TextEditingController();
+  Timer? _draftSaveDebounce;
 
   DateTime? _selectedDate;
   TimeOfDay? _selectedTime;
@@ -41,8 +46,15 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
   String _destination = '';
   RidePaymentOption _paymentOption = RidePaymentOption.card;
   bool _isResolvingOriginFromGps = false;
+  bool _isDraftLoaded = false;
+  bool _isRestoringDraft = false;
+  bool _draftRestored = false;
+  bool _hasPendingSyncDraft = false;
+  bool _isPendingSyncAttemptInFlight = false;
   String? _originLocationError;
   String? _currentLocationSuggestion;
+  String? _draftSyncReason;
+  DateTime? _draftSavedAt;
 
   static const List<String> _campusLocations = <String>[
     'Campus Uniandes - Main Gate',
@@ -58,11 +70,25 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(_prefillOriginWithCurrentLocation);
+    _notesController.addListener(_onDraftFieldChanged);
+    _dateController.addListener(_onDraftFieldChanged);
+    _timeController.addListener(_onDraftFieldChanged);
+    _durationController.addListener(_onDraftFieldChanged);
+    _priceController.addListener(_onDraftFieldChanged);
+    Future.microtask(() async {
+      await _restoreDraftIfAvailable();
+      await _prefillOriginWithCurrentLocation();
+    });
   }
 
   @override
   void dispose() {
+    _draftSaveDebounce?.cancel();
+    _notesController.removeListener(_onDraftFieldChanged);
+    _dateController.removeListener(_onDraftFieldChanged);
+    _timeController.removeListener(_onDraftFieldChanged);
+    _durationController.removeListener(_onDraftFieldChanged);
+    _priceController.removeListener(_onDraftFieldChanged);
     _notesController.dispose();
     _dateController.dispose();
     _timeController.dispose();
@@ -93,6 +119,268 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
     }
   }
 
+  String get _draftCacheId {
+    final currentUser = ref.read(authUserProvider);
+    return currentUser?.uid ?? 'anonymous_create_ride';
+  }
+
+  void _onDraftFieldChanged() {
+    if (_isRestoringDraft) {
+      return;
+    }
+
+    _scheduleDraftAutosave();
+  }
+
+  void _scheduleDraftAutosave() {
+    _draftSaveDebounce?.cancel();
+    _draftSaveDebounce = Timer(const Duration(milliseconds: 350), () {
+      unawaited(_persistDraftSnapshot());
+    });
+  }
+
+  Future<void> _restoreDraftIfAvailable() async {
+    final draft = await ref
+        .read(createRideDraftLocalDataSourceProvider)
+        .loadDraft(cacheId: _draftCacheId);
+
+    if (!mounted) {
+      return;
+    }
+
+    if (draft == null || !draft.hasMeaningfulData) {
+      setState(() {
+        _isDraftLoaded = true;
+      });
+      return;
+    }
+
+    _isRestoringDraft = true;
+    _originFieldKey.currentState?.didChange(draft.origin);
+
+    final restoredDate = _parseDraftDate(draft.dateText);
+    final restoredTime = _parseDraftTime(draft.timeText);
+
+    setState(() {
+      _origin = draft.origin;
+      _destination = draft.destination;
+      _notesController.text = draft.notes;
+      _dateController.text = draft.dateText;
+      _timeController.text = draft.timeText;
+      _durationController.text = draft.durationText;
+      _priceController.text = draft.priceText;
+      _selectedDate = restoredDate;
+      _selectedTime = restoredTime;
+      _availableSeats = draft.availableSeats.clamp(1, 4);
+      _paymentOption = draft.paymentOption;
+      _currentLocationSuggestion = draft.currentLocationSuggestion;
+      _hasPendingSyncDraft = draft.pendingSync;
+      _draftSyncReason = draft.pendingSyncReason;
+      _draftSavedAt = draft.savedAt.toLocal();
+      _draftRestored = true;
+      _isDraftLoaded = true;
+    });
+
+    _isRestoringDraft = false;
+
+    if (_hasPendingSyncDraft) {
+      final isOnline = await ref.read(connectivityServiceProvider).hasConnection();
+      if (!mounted || !isOnline) {
+        return;
+      }
+      await _attemptPendingDraftSync(triggeredAutomatically: true);
+    }
+  }
+
+  LocalCreateRideDraftModel _buildDraftSnapshot({
+    bool? pendingSync,
+    String? pendingSyncReason,
+  }) {
+    final effectivePendingSync = pendingSync ?? _hasPendingSyncDraft;
+    final effectiveReason =
+        pendingSyncReason ?? (effectivePendingSync ? _draftSyncReason : null);
+
+    return LocalCreateRideDraftModel.create(
+      origin: _origin.trim(),
+      destination: _destination.trim(),
+      notes: _notesController.text.trim(),
+      dateText: _dateController.text.trim(),
+      timeText: _timeController.text.trim(),
+      durationText: _durationController.text.trim(),
+      priceText: _priceController.text.trim(),
+      availableSeats: _availableSeats,
+      paymentOption: _paymentOption,
+      currentLocationSuggestion: _currentLocationSuggestion,
+      pendingSync: effectivePendingSync,
+      pendingSyncReason: effectiveReason,
+      pendingSyncRequestedAt: effectivePendingSync ? DateTime.now() : null,
+    );
+  }
+
+  Future<void> _persistDraftSnapshot({
+    bool? pendingSync,
+    String? pendingSyncReason,
+    bool showFeedback = false,
+  }) async {
+    final draft = _buildDraftSnapshot(
+      pendingSync: pendingSync,
+      pendingSyncReason: pendingSyncReason,
+    );
+
+    final localDataSource = ref.read(createRideDraftLocalDataSourceProvider);
+    if (!draft.hasMeaningfulData) {
+      await localDataSource.clearDraft(cacheId: _draftCacheId);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _draftRestored = false;
+        _hasPendingSyncDraft = false;
+        _draftSyncReason = null;
+        _draftSavedAt = null;
+      });
+      return;
+    }
+
+    await localDataSource.saveDraft(cacheId: _draftCacheId, draft: draft);
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _draftSavedAt = draft.savedAt.toLocal();
+      _hasPendingSyncDraft = draft.pendingSync;
+      _draftSyncReason = draft.pendingSyncReason;
+    });
+
+    if (showFeedback) {
+      final message = draft.pendingSync
+          ? 'Ride saved locally and queued for sync when internet returns.'
+          : 'Ride draft saved on this device.';
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(SnackBar(content: Text(message)));
+    }
+  }
+
+  Future<void> _clearDraft({
+    bool resetForm = false,
+    bool showFeedback = false,
+  }) async {
+    await ref
+        .read(createRideDraftLocalDataSourceProvider)
+        .clearDraft(cacheId: _draftCacheId);
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _draftRestored = false;
+      _hasPendingSyncDraft = false;
+      _draftSyncReason = null;
+      _draftSavedAt = null;
+    });
+
+    if (resetForm) {
+      _resetFormToInitialState();
+    }
+
+    if (showFeedback) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(content: Text('Saved ride draft discarded.')),
+        );
+    }
+  }
+
+  void _resetFormToInitialState() {
+    _isRestoringDraft = true;
+    _originFieldKey.currentState?.didChange('');
+    setState(() {
+      _origin = '';
+      _destination = '';
+      _notesController.clear();
+      _dateController.clear();
+      _timeController.clear();
+      _durationController.text = '30';
+      _priceController.clear();
+      _selectedDate = null;
+      _selectedTime = null;
+      _availableSeats = 3;
+      _paymentOption = RidePaymentOption.card;
+      _draftRestored = false;
+      _hasPendingSyncDraft = false;
+      _draftSyncReason = null;
+      _draftSavedAt = null;
+    });
+    _isRestoringDraft = false;
+    unawaited(_prefillOriginWithCurrentLocation());
+  }
+
+  DateTime? _parseDraftDate(String value) {
+    final parts = value.split('/');
+    if (parts.length != 3) {
+      return null;
+    }
+
+    final day = int.tryParse(parts[0]);
+    final month = int.tryParse(parts[1]);
+    final year = int.tryParse(parts[2]);
+    if (day == null || month == null || year == null) {
+      return null;
+    }
+
+    return DateTime(year, month, day);
+  }
+
+  TimeOfDay? _parseDraftTime(String value) {
+    final parts = value.split(':');
+    if (parts.length != 2) {
+      return null;
+    }
+
+    final hour = int.tryParse(parts[0]);
+    final minute = int.tryParse(parts[1]);
+    if (hour == null || minute == null) {
+      return null;
+    }
+
+    return TimeOfDay(hour: hour, minute: minute);
+  }
+
+  bool _looksLikeConnectivityFailure(Object error) {
+    final normalized = error.toString().toLowerCase();
+    return normalized.contains('network') ||
+        normalized.contains('offline') ||
+        normalized.contains('connection') ||
+        normalized.contains('unavailable') ||
+        normalized.contains('socket');
+  }
+
+  Future<void> _attemptPendingDraftSync({
+    required bool triggeredAutomatically,
+  }) async {
+    if (_isPendingSyncAttemptInFlight || !_hasPendingSyncDraft) {
+      return;
+    }
+
+    setState(() {
+      _isPendingSyncAttemptInFlight = true;
+    });
+
+    try {
+      await _publishRide(triggeredAutomatically: triggeredAutomatically);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPendingSyncAttemptInFlight = false;
+        });
+      }
+    }
+  }
+
   Future<void> _useCurrentLocationAsOrigin() async {
     setState(() {
       _isResolvingOriginFromGps = true;
@@ -112,6 +400,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
         _origin = address;
         _currentLocationSuggestion = address;
       });
+      _scheduleDraftAutosave();
 
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Pickup location updated from GPS.')),
@@ -176,10 +465,11 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
       return;
     }
 
-    setState(() {
-      _selectedDate = pickedDate;
-      _dateController.text = _formatDate(pickedDate);
-    });
+      setState(() {
+        _selectedDate = pickedDate;
+        _dateController.text = _formatDate(pickedDate);
+      });
+      _scheduleDraftAutosave();
   }
 
   Future<void> _pickTime() async {
@@ -195,6 +485,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
       _selectedTime = pickedTime;
       _timeController.text = _formatTime(pickedTime);
     });
+    _scheduleDraftAutosave();
   }
 
   String _formatDate(DateTime value) {
@@ -207,6 +498,14 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
     final hour = value.hour.toString().padLeft(2, '0');
     final minute = value.minute.toString().padLeft(2, '0');
     return '$hour:$minute';
+  }
+
+  String _formatDraftSavedAt(DateTime value) {
+    final day = value.day.toString().padLeft(2, '0');
+    final month = value.month.toString().padLeft(2, '0');
+    final hour = value.hour.toString().padLeft(2, '0');
+    final minute = value.minute.toString().padLeft(2, '0');
+    return '$day/$month/${value.year} $hour:$minute';
   }
 
   int get _durationMinutes {
@@ -229,7 +528,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
   double get _estimatedNetIfAllSeatsPayByCard =>
       _availableSeats * _estimatedNetPerCardSeat;
 
-  Future<void> _publishRide() async {
+  Future<void> _publishRide({bool triggeredAutomatically = false}) async {
     final isValid = _formKey.currentState?.validate() ?? false;
     if (!isValid) {
       return;
@@ -269,37 +568,73 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
       return;
     }
 
-    final rideId = await ref
-        .read(createRideControllerProvider.notifier)
-        .createRide(
-          driverId: currentUser.uid,
-          driverName: currentUser.fullName,
-          driverEmail: currentUser.email,
-          origin: _origin.trim(),
-          destination: _destination.trim(),
-          departureAt: departureAt,
-          estimatedDurationMinutes: _durationMinutes,
-          totalSeats: _availableSeats,
-          pricePerSeat: _pricePerSeat,
-          paymentOption: _paymentOption,
-          notes: _notesController.text.trim(),
-        );
-
-    if (!mounted || rideId == null) {
+    final isOnline = await ref.read(connectivityServiceProvider).hasConnection();
+    if (!isOnline) {
+      await _persistDraftSnapshot(
+        pendingSync: true,
+        pendingSyncReason: 'offline_publish_attempt',
+        showFeedback: !triggeredAutomatically,
+      );
       return;
     }
 
-    ref.read(createRideControllerProvider.notifier).clear();
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Ride published successfully.')),
-    );
-    context.go(AppRoutes.activeRideById(rideId));
+    try {
+      final rideId = await ref
+          .read(createRideControllerProvider.notifier)
+          .createRide(
+            driverId: currentUser.uid,
+            driverName: currentUser.fullName,
+            driverEmail: currentUser.email,
+            origin: _origin.trim(),
+            destination: _destination.trim(),
+            departureAt: departureAt,
+            estimatedDurationMinutes: _durationMinutes,
+            totalSeats: _availableSeats,
+            pricePerSeat: _pricePerSeat,
+            paymentOption: _paymentOption,
+            notes: _notesController.text.trim(),
+          );
+
+      if (!mounted || rideId == null) {
+        return;
+      }
+
+      await _clearDraft();
+      if (!mounted) {
+        return;
+      }
+      ref.read(createRideControllerProvider.notifier).clear();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            triggeredAutomatically
+                ? 'Saved ride draft published automatically.'
+                : 'Ride published successfully.',
+          ),
+        ),
+      );
+      context.go(AppRoutes.activeRideById(rideId));
+    } catch (error) {
+      if (_looksLikeConnectivityFailure(error)) {
+        await _persistDraftSnapshot(
+          pendingSync: true,
+          pendingSyncReason: 'publish_failed_connectivity',
+          showFeedback: !triggeredAutomatically,
+        );
+        return;
+      }
+
+      await _persistDraftSnapshot(showFeedback: false);
+      rethrow;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final role = ref.watch(currentUserRoleProvider);
     final createRideState = ref.watch(createRideControllerProvider);
+    final connectivityAsync = ref.watch(connectivityStatusProvider);
+    final isOnline = connectivityAsync.valueOrNull ?? true;
     final palette = context.palette;
 
     ref.listen<AsyncValue<String?>>(createRideControllerProvider, (
@@ -316,6 +651,20 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
             ..showSnackBar(SnackBar(content: Text(message)));
         },
       );
+    });
+
+    ref.listen<AsyncValue<bool>>(connectivityStatusProvider, (previous, next) {
+      final previousValue = previous?.valueOrNull;
+      final nextValue = next.valueOrNull;
+      if (previousValue == nextValue) {
+        return;
+      }
+
+      if (nextValue == true && _hasPendingSyncDraft) {
+        Future.microtask(() {
+          _attemptPendingDraftSync(triggeredAutomatically: true);
+        });
+      }
     });
 
     return AppScaffold(
@@ -351,7 +700,10 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
               child: SizedBox(
                 width: double.infinity,
                 child: ElevatedButton.icon(
-                  onPressed: createRideState.isLoading ? null : _publishRide,
+                  onPressed:
+                      createRideState.isLoading || _isPendingSyncAttemptInFlight
+                      ? null
+                      : () => _publishRide(),
                   style: ElevatedButton.styleFrom(
                     backgroundColor: palette.accent,
                     foregroundColor: palette.accentForeground,
@@ -385,16 +737,28 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
           key: _formKey,
           child: Column(
             children: [
+              if (_isDraftLoaded &&
+                  (_draftRestored || _hasPendingSyncDraft || !isOnline)) ...[
+                _draftStatusCard(
+                  isOnline: isOnline,
+                  isSyncing: _isPendingSyncAttemptInFlight,
+                ),
+                const SizedBox(height: AppSpacing.m),
+              ],
               _sectionCard(
                 title: 'Route Details',
                 child: Column(
                   children: [
                     _locationAutocompleteField(
                       fieldKey: _originFieldKey,
+                      currentValueOverride: _origin,
                       label: 'Pickup Location',
                       hint: 'e.g. Campus Uniandes - Main Gate',
                       icon: Icons.location_pin,
-                      onChanged: (value) => _origin = value,
+                      onChanged: (value) {
+                        _origin = value;
+                        _scheduleDraftAutosave();
+                      },
                       validatorText: 'Pickup location is required.',
                       suggestions: _locationSuggestionsFor,
                       suffixIcon: _isResolvingOriginFromGps
@@ -442,10 +806,14 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
                     ],
                     const SizedBox(height: AppSpacing.m),
                     _locationAutocompleteField(
+                      currentValueOverride: _destination,
                       label: 'Destination',
                       hint: 'e.g. Centro Comercial Andino',
                       icon: Icons.place_outlined,
-                      onChanged: (value) => _destination = value,
+                      onChanged: (value) {
+                        _destination = value;
+                        _scheduleDraftAutosave();
+                      },
                       validatorText: 'Destination is required.',
                       suggestions: _locationSuggestionsFor,
                     ),
@@ -531,6 +899,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
                           onTap: _availableSeats > 1
                               ? () => setState(() {
                                   _availableSeats -= 1;
+                                  _scheduleDraftAutosave();
                                 })
                               : null,
                         ),
@@ -557,6 +926,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
                           onTap: _availableSeats < 4
                               ? () => setState(() {
                                   _availableSeats += 1;
+                                  _scheduleDraftAutosave();
                                 })
                               : null,
                         ),
@@ -618,6 +988,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
                         setState(() {
                           _paymentOption = RidePaymentOption.card;
                         });
+                        _scheduleDraftAutosave();
                       },
                     ),
                     const SizedBox(height: AppSpacing.s),
@@ -634,6 +1005,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
                         setState(() {
                           _paymentOption = RidePaymentOption.bankTransfer;
                         });
+                        _scheduleDraftAutosave();
                       },
                     ),
                     const SizedBox(height: AppSpacing.m),
@@ -753,8 +1125,149 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
     );
   }
 
+  Widget _draftStatusCard({
+    required bool isOnline,
+    required bool isSyncing,
+  }) {
+    final palette = context.palette;
+    final title = _hasPendingSyncDraft
+        ? isSyncing
+              ? 'Syncing saved ride draft'
+              : isOnline
+              ? 'Ride draft ready to sync'
+              : 'Ride draft saved offline'
+        : _draftRestored
+        ? 'Recovered local ride draft'
+        : 'Offline mode';
+
+    final message = _hasPendingSyncDraft
+        ? isSyncing
+              ? 'We are retrying the ride publication now that connectivity is available.'
+              : isOnline
+              ? 'This draft was saved after a failed publish attempt. You can wait for automatic sync or publish again manually.'
+              : 'Your ride was saved locally after a publish attempt without internet. It will retry once the connection returns.'
+        : _draftRestored
+        ? 'This device restored your latest saved Create Ride draft so you can continue where you left off.'
+        : 'You are offline. Any progress on this form can still be saved locally on this device.';
+
+    final savedAtLabel = _draftSavedAt == null
+        ? null
+        : 'Last local save: ${_formatDraftSavedAt(_draftSavedAt!)}';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: _hasPendingSyncDraft
+            ? palette.secondarySoft
+            : palette.primary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        border: Border.all(
+          color: _hasPendingSyncDraft ? palette.secondary : palette.border,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                _hasPendingSyncDraft
+                    ? Icons.sync_problem_outlined
+                    : Icons.save_outlined,
+                color: _hasPendingSyncDraft ? palette.secondary : palette.primary,
+              ),
+              const SizedBox(width: AppSpacing.s),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        color: palette.textPrimary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    Text(
+                      message,
+                      style: TextStyle(
+                        color: palette.textSecondary,
+                        height: 1.35,
+                      ),
+                    ),
+                    if (savedAtLabel != null) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        savedAtLabel,
+                        style: TextStyle(
+                          color: palette.textSecondary,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                    if (_draftSyncReason != null && _hasPendingSyncDraft) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        'Sync reason: ${_draftSyncReason!.replaceAll('_', ' ')}',
+                        style: TextStyle(
+                          color: palette.textSecondary,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.m),
+          Wrap(
+            spacing: AppSpacing.s,
+            runSpacing: AppSpacing.s,
+            children: [
+              OutlinedButton.icon(
+                onPressed: isSyncing
+                    ? null
+                    : () => _persistDraftSnapshot(showFeedback: true),
+                icon: const Icon(Icons.save_alt_outlined, size: 18),
+                label: const Text('Save draft now'),
+              ),
+              if (_hasPendingSyncDraft && isOnline)
+                OutlinedButton.icon(
+                  onPressed: isSyncing
+                      ? null
+                      : () => _attemptPendingDraftSync(
+                          triggeredAutomatically: false,
+                        ),
+                  icon: isSyncing
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.cloud_upload_outlined, size: 18),
+                  label: Text(isSyncing ? 'Syncing...' : 'Retry sync'),
+                ),
+              OutlinedButton.icon(
+                onPressed: isSyncing
+                    ? null
+                    : () => _clearDraft(resetForm: true, showFeedback: true),
+                icon: const Icon(Icons.delete_outline, size: 18),
+                label: const Text('Discard draft'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _locationAutocompleteField({
     GlobalKey<FormFieldState<String>>? fieldKey,
+    required String currentValueOverride,
     required String label,
     required String hint,
     required IconData icon,
@@ -765,16 +1278,21 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
   }) {
     return FormField<String>(
       key: fieldKey,
-      initialValue: '',
+      initialValue: currentValueOverride,
       validator: (value) {
-        if (value == null || value.trim().isEmpty) {
+        final effectiveValue = (value == null || value.trim().isEmpty)
+            ? currentValueOverride
+            : value;
+        if (effectiveValue.trim().isEmpty) {
           return validatorText;
         }
         return null;
       },
       builder: (field) {
         final palette = context.palette;
-        final currentValue = field.value ?? '';
+        final currentValue = (field.value == null || field.value!.trim().isEmpty)
+            ? currentValueOverride
+            : field.value!;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/wheels/lib/shared/storage/app_hive.dart
+++ b/wheels/lib/shared/storage/app_hive.dart
@@ -3,6 +3,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 class AppHiveBoxes {
   static const String rideDetailsCache = 'ride_details_cache_box_v1';
   static const String dashboardCache = 'dashboard_cache_box_v1';
+  static const String createRideDrafts = 'create_ride_drafts_box_v1';
 }
 
 class AppHiveKeys {
@@ -14,4 +15,5 @@ Future<void> initializeAppHive() async {
   await Hive.initFlutter();
   await Hive.openBox<String>(AppHiveBoxes.rideDetailsCache);
   await Hive.openBox<String>(AppHiveBoxes.dashboardCache);
+  await Hive.openBox<String>(AppHiveBoxes.createRideDrafts);
 }


### PR DESCRIPTION
## PR Description

### Title
Add offline draft and pending sync support to Create Ride

### Description
This PR adds eventual connectivity support to the ride creation flow by introducing local draft persistence in `CreateRideScreen`. Drivers can now keep their form progress even if the app is closed or the device loses connectivity, and failed publish attempts caused by being offline are preserved as pending drafts instead of being lost.

### What changed
- Added a local draft model for ride creation form data
- Added a local datasource backed by Hive to save, restore, and clear ride drafts
- Extended Hive initialization with a dedicated box for create ride drafts
- Integrated automatic draft restoration when `CreateRideScreen` opens
- Added autosave behavior while the user edits the form
- Added offline-aware publish behavior:
  - if the device is offline, the ride is stored locally as a `pending sync` draft
  - when connectivity returns, the app retries publishing automatically
- Added a status card in `CreateRideScreen` to show:
  - recovered drafts
  - pending sync state
  - retry sync action
  - discard draft action

### Why this matters
This improves the user experience in unstable network conditions and directly supports the eventual connectivity requirement of the project. Drivers no longer lose ride form progress, and ride publishing can recover gracefully once internet access returns.

### Implementation notes
- Storage strategy: Hive
- Cache format: serialized JSON snapshot
- Screen affected: `CreateRideScreen`
- New local persistence components:
  - `local_create_ride_draft_model.dart`
  - `create_ride_draft_local_datasource.dart`

### Result
`CreateRideScreen` now behaves as an offline-capable draft workflow instead of a network-only form.
