### PR TITLE
Implemented offline wallet snapshot

### DIFF
--- a/wheels/lib/features/wallet/data/datasources/wallet_summary_local_datasource.dart
+++ b/wheels/lib/features/wallet/data/datasources/wallet_summary_local_datasource.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../../../../shared/storage/app_hive.dart';
+import '../models/local_wallet_summary_cache_model.dart';
+
+LocalWalletSummaryCacheModel _decodeWalletSummaryCache(String rawCache) {
+  final decoded = jsonDecode(rawCache);
+  if (decoded is! Map) {
+    throw const FormatException('Stored wallet cache is invalid.');
+  }
+
+  return LocalWalletSummaryCacheModel.fromJson(
+    Map<String, dynamic>.from(decoded),
+  );
+}
+
+String _encodeWalletSummaryCache(LocalWalletSummaryCacheModel cache) {
+  return jsonEncode(cache.toJson());
+}
+
+class WalletSummaryLocalDataSource {
+  const WalletSummaryLocalDataSource();
+
+  Future<LocalWalletSummaryCacheModel?> loadLatestWalletSummary() async {
+    final box = Hive.box<String>(AppHiveBoxes.walletSummaryCache);
+    final rawCache = box.get(AppHiveKeys.latestWalletSummary);
+    if (rawCache == null || rawCache.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      return await compute(_decodeWalletSummaryCache, rawCache);
+    } catch (_) {
+      await clearLatestWalletSummary();
+      return null;
+    }
+  }
+
+  Future<void> saveLatestWalletSummary(
+    LocalWalletSummaryCacheModel cache,
+  ) async {
+    final encoded = await compute(_encodeWalletSummaryCache, cache);
+    final box = Hive.box<String>(AppHiveBoxes.walletSummaryCache);
+    await box.put(AppHiveKeys.latestWalletSummary, encoded);
+  }
+
+  Future<void> clearLatestWalletSummary() async {
+    final box = Hive.box<String>(AppHiveBoxes.walletSummaryCache);
+    await box.delete(AppHiveKeys.latestWalletSummary);
+  }
+}

--- a/wheels/lib/features/wallet/data/models/local_wallet_summary_cache_model.dart
+++ b/wheels/lib/features/wallet/data/models/local_wallet_summary_cache_model.dart
@@ -1,0 +1,72 @@
+import '../../domain/entities/wallet_summary.dart';
+import 'wallet_summary_model.dart';
+
+class LocalWalletSummaryCacheModel {
+  const LocalWalletSummaryCacheModel({
+    required this.version,
+    required this.savedAt,
+    required this.summary,
+  });
+
+  final int version;
+  final DateTime savedAt;
+  final WalletSummaryModel summary;
+
+  factory LocalWalletSummaryCacheModel.create({
+    required WalletSummary summary,
+    DateTime? savedAt,
+  }) {
+    return LocalWalletSummaryCacheModel(
+      version: 1,
+      savedAt: savedAt ?? DateTime.now(),
+      summary: WalletSummaryModel(
+        availableBalance: summary.availableBalance,
+        pendingWithdrawalBalance: summary.pendingWithdrawalBalance,
+        totalEarned: summary.totalEarned,
+      ),
+    );
+  }
+
+  factory LocalWalletSummaryCacheModel.fromJson(Map<String, dynamic> json) {
+    final version = (json['version'] as num?)?.toInt() ?? 1;
+    if (version != 1) {
+      throw FormatException('Unsupported wallet cache version: $version');
+    }
+
+    final savedAtRaw = json['savedAt'];
+    final summaryRaw = json['summary'];
+
+    if (savedAtRaw is! String || summaryRaw is! Map) {
+      throw const FormatException('Stored wallet cache is invalid.');
+    }
+
+    final savedAt = DateTime.tryParse(savedAtRaw);
+    if (savedAt == null) {
+      throw const FormatException('Stored wallet cache has an invalid date.');
+    }
+
+    return LocalWalletSummaryCacheModel(
+      version: version,
+      savedAt: savedAt,
+      summary: WalletSummaryModel.fromJson(
+        Map<String, dynamic>.from(summaryRaw),
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'version': version,
+      'savedAt': savedAt.toIso8601String(),
+      'summary': summary.toJson(),
+    };
+  }
+
+  WalletSummary toEntity() {
+    return WalletSummary(
+      availableBalance: summary.availableBalance,
+      pendingWithdrawalBalance: summary.pendingWithdrawalBalance,
+      totalEarned: summary.totalEarned,
+    );
+  }
+}

--- a/wheels/lib/features/wallet/presentation/providers/wallet_providers.dart
+++ b/wheels/lib/features/wallet/presentation/providers/wallet_providers.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../../data/datasources/wallet_remote_datasource.dart';
+import '../../data/datasources/wallet_summary_local_datasource.dart';
 import '../../data/repositories/wallet_repository_impl.dart';
 import '../../domain/entities/withdrawal_request_input.dart';
 import '../../domain/entities/wallet_summary.dart';
@@ -10,6 +11,11 @@ import '../../domain/repositories/wallet_repository.dart';
 final walletRemoteDataSourceProvider = Provider<WalletRemoteDataSource>((ref) {
   return WalletRemoteDataSource();
 });
+
+final walletSummaryLocalDataSourceProvider =
+    Provider<WalletSummaryLocalDataSource>((ref) {
+      return const WalletSummaryLocalDataSource();
+    });
 
 final walletRepositoryProvider = Provider<WalletRepository>((ref) {
   return WalletRepositoryImpl(

--- a/wheels/lib/features/wallet/presentation/screens/wallet_screen.dart
+++ b/wheels/lib/features/wallet/presentation/screens/wallet_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../router/app_routes.dart';
+import '../../../../shared/providers/connectivity_provider.dart';
 import '../../../../shared/ui/app_scaffold.dart';
 import '../../../../shared/utils/app_formatter.dart';
 import '../../../../shared/widgets/app_bottom_nav.dart';
@@ -12,24 +13,179 @@ import '../../../../theme/app_shadows.dart';
 import '../../../../theme/app_spacing.dart';
 import '../../../../theme/app_theme_palette.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/models/local_wallet_summary_cache_model.dart';
 import '../../domain/entities/wallet_summary.dart';
 import '../providers/wallet_providers.dart';
 
-class WalletScreen extends ConsumerWidget {
+class WalletScreen extends ConsumerStatefulWidget {
   const WalletScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<WalletScreen> createState() => _WalletScreenState();
+}
+
+class _WalletScreenState extends ConsumerState<WalletScreen> {
+  LocalWalletSummaryCacheModel? _cachedWalletSnapshot;
+  bool _isRestoringCache = true;
+  bool _isUsingCachedFallback = false;
+  Object? _lastLiveError;
+
+  @override
+  void initState() {
+    super.initState();
+    Future<void>.microtask(_restoreWalletSnapshot);
+  }
+
+  Future<void> _restoreWalletSnapshot() async {
+    final cache = await ref
+        .read(walletSummaryLocalDataSourceProvider)
+        .loadLatestWalletSummary();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _cachedWalletSnapshot = cache;
+      _isRestoringCache = false;
+    });
+  }
+
+  Future<void> _persistWalletSnapshot(WalletSummary summary) async {
+    final snapshot = LocalWalletSummaryCacheModel.create(summary: summary);
+    await ref
+        .read(walletSummaryLocalDataSourceProvider)
+        .saveLatestWalletSummary(snapshot);
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _cachedWalletSnapshot = snapshot;
+      _isUsingCachedFallback = false;
+      _lastLiveError = null;
+    });
+  }
+
+  void _handleWalletSummaryUpdate(
+    AsyncValue<WalletSummary?>? previous,
+    AsyncValue<WalletSummary?> next,
+  ) {
+    next.whenData((summary) {
+      if (summary == null) {
+        return;
+      }
+
+      _persistWalletSnapshot(summary);
+    });
+
+    if (!mounted) {
+      return;
+    }
+
+    if (next.hasError) {
+      final shouldUseCache = _cachedWalletSnapshot != null;
+      setState(() {
+        _lastLiveError = next.error;
+        _isUsingCachedFallback = shouldUseCache;
+      });
+      return;
+    }
+
+    if (previous?.hasError == true && next.isLoading) {
+      return;
+    }
+
+    if (_isUsingCachedFallback || _lastLiveError != null) {
+      setState(() {
+        _isUsingCachedFallback = false;
+        _lastLiveError = null;
+      });
+    }
+  }
+
+  void _handleConnectivityUpdate(
+    AsyncValue<bool>? previous,
+    AsyncValue<bool> next,
+  ) {
+    final wasOnline = previous?.valueOrNull ?? true;
+    final isOnline = next.valueOrNull ?? true;
+
+    if (!mounted || !isOnline || wasOnline == isOnline) {
+      return;
+    }
+
+    if (_isUsingCachedFallback || _lastLiveError != null) {
+      ref.invalidate(driverWalletSummaryProvider);
+    }
+  }
+
+  void _refreshWalletSummary() {
+    ref.invalidate(driverWalletSummaryProvider);
+  }
+
+  String _formatCachedAt(DateTime savedAt) {
+    final date = '${savedAt.day}/${savedAt.month}/${savedAt.year}';
+    final hour = TimeOfDay.fromDateTime(savedAt).format(context);
+    return '$date at $hour';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<AsyncValue<WalletSummary?>>(
+      driverWalletSummaryProvider,
+      _handleWalletSummaryUpdate,
+    );
+    ref.listen<AsyncValue<bool>>(
+      connectivityStatusProvider,
+      _handleConnectivityUpdate,
+    );
+
     final role = ref.watch(currentUserRoleProvider);
     final user = ref.watch(authUserProvider);
     final walletSummaryAsync = ref.watch(driverWalletSummaryProvider);
-    final palette = context.palette;
+    final connectivityAsync = ref.watch(connectivityStatusProvider);
+    final isOnline = connectivityAsync.valueOrNull ?? true;
+
+    final liveSummary = walletSummaryAsync.valueOrNull;
+    final cachedSummary = _cachedWalletSnapshot?.toEntity();
+    final shouldUseCachedSummary =
+        cachedSummary != null &&
+        (!isOnline ||
+            _isUsingCachedFallback ||
+            (walletSummaryAsync.hasError && liveSummary == null));
+    final summary = shouldUseCachedSummary ? cachedSummary : liveSummary;
+    final cachedAt = _cachedWalletSnapshot?.savedAt;
+
+    final Widget child;
+    if (user == null || role != UserRole.driver) {
+      child = const _WalletAccessCard();
+    } else if (summary != null) {
+      child = _WalletContent(
+        summary: summary,
+        showCachedNotice: shouldUseCachedSummary,
+        isOnline: isOnline,
+        cachedAtLabel: cachedAt == null ? null : _formatCachedAt(cachedAt),
+      );
+    } else if (walletSummaryAsync.isLoading || _isRestoringCache) {
+      child = const _WalletLoadingState();
+    } else if (walletSummaryAsync.hasError) {
+      child = _WalletErrorState(
+        message: walletSummaryAsync.error.toString().replaceFirst(
+          'Exception: ',
+          '',
+        ),
+        onRetry: _refreshWalletSummary,
+      );
+    } else {
+      child = const _WalletAccessCard();
+    }
 
     return AppScaffold(
       title: 'Driver Wallet',
       actions: [
         IconButton(
-          onPressed: () => ref.invalidate(driverWalletSummaryProvider),
+          onPressed: _refreshWalletSummary,
           icon: const Icon(Icons.refresh_rounded),
           tooltip: 'Refresh wallet',
         ),
@@ -38,76 +194,148 @@ class WalletScreen extends ConsumerWidget {
         currentTab: AppBottomNavTab.profile,
         role: role,
       ),
-      child: user == null || role != UserRole.driver
-          ? const _WalletAccessCard()
-          : walletSummaryAsync.when(
-              loading: () => const _WalletLoadingState(),
-              error: (error, _) => _WalletErrorState(
-                message: error.toString().replaceFirst('Exception: ', ''),
-                onRetry: () => ref.invalidate(driverWalletSummaryProvider),
-              ),
-              data: (summary) {
-                if (summary == null) {
-                  return const _WalletAccessCard();
-                }
+      child: child,
+    );
+  }
+}
 
-                return SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      _WalletHeroCard(summary: summary),
-                      const SizedBox(height: AppSpacing.l),
-                      if (summary.isEmpty) ...[
-                        const _WalletEmptyState(),
-                        const SizedBox(height: AppSpacing.l),
-                      ],
-                      Row(
-                        children: [
-                          Expanded(
-                            child: _WalletStatCard(
-                              label: 'Available',
-                              value: AppFormatter.cop(summary.availableBalance),
-                              icon: Icons.account_balance_wallet_outlined,
-                              color: palette.primary,
-                            ),
-                          ),
-                          const SizedBox(width: AppSpacing.s),
-                          Expanded(
-                            child: _WalletStatCard(
-                              label: 'Pending withdrawal',
-                              value: AppFormatter.cop(
-                                summary.pendingWithdrawalBalance,
-                              ),
-                              icon: Icons.hourglass_top_rounded,
-                              color: palette.warning,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: AppSpacing.s),
-                      _WalletStatCard(
-                        label: 'Total earned',
-                        value: AppFormatter.cop(summary.totalEarned),
-                        icon: Icons.trending_up_rounded,
-                        color: palette.accent,
-                        fullWidth: true,
-                      ),
-                      const SizedBox(height: AppSpacing.l),
-                      const _WalletInfoCard(),
-                      const SizedBox(height: AppSpacing.l),
-                      AppButton(
-                        label: summary.canRequestWithdrawal
-                            ? 'Request withdrawal'
-                            : 'Withdrawal available from COP 10.000',
-                        onPressed: summary.canRequestWithdrawal
-                            ? () => context.go(AppRoutes.withdrawalRequest)
-                            : null,
-                      ),
-                    ],
-                  ),
-                );
-              },
+class _WalletContent extends StatelessWidget {
+  const _WalletContent({
+    required this.summary,
+    required this.showCachedNotice,
+    required this.isOnline,
+    required this.cachedAtLabel,
+  });
+
+  final WalletSummary summary;
+  final bool showCachedNotice;
+  final bool isOnline;
+  final String? cachedAtLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (showCachedNotice) ...[
+            _WalletCachedNotice(
+              isOnline: isOnline,
+              cachedAtLabel: cachedAtLabel,
             ),
+            const SizedBox(height: AppSpacing.l),
+          ],
+          _WalletHeroCard(summary: summary),
+          const SizedBox(height: AppSpacing.l),
+          if (summary.isEmpty) ...[
+            const _WalletEmptyState(),
+            const SizedBox(height: AppSpacing.l),
+          ],
+          Row(
+            children: [
+              Expanded(
+                child: _WalletStatCard(
+                  label: 'Available',
+                  value: AppFormatter.cop(summary.availableBalance),
+                  icon: Icons.account_balance_wallet_outlined,
+                  color: palette.primary,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.s),
+              Expanded(
+                child: _WalletStatCard(
+                  label: 'Pending withdrawal',
+                  value: AppFormatter.cop(summary.pendingWithdrawalBalance),
+                  icon: Icons.hourglass_top_rounded,
+                  color: palette.warning,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.s),
+          _WalletStatCard(
+            label: 'Total earned',
+            value: AppFormatter.cop(summary.totalEarned),
+            icon: Icons.trending_up_rounded,
+            color: palette.accent,
+            fullWidth: true,
+          ),
+          const SizedBox(height: AppSpacing.l),
+          const _WalletInfoCard(),
+          const SizedBox(height: AppSpacing.l),
+          AppButton(
+            label: summary.canRequestWithdrawal
+                ? 'Request withdrawal'
+                : 'Withdrawal available from COP 10.000',
+            onPressed: summary.canRequestWithdrawal
+                ? () => context.go(AppRoutes.withdrawalRequest)
+                : null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WalletCachedNotice extends StatelessWidget {
+  const _WalletCachedNotice({
+    required this.isOnline,
+    required this.cachedAtLabel,
+  });
+
+  final bool isOnline;
+  final String? cachedAtLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final title = isOnline ? 'Showing cached wallet data' : 'You are offline';
+    final message = isOnline
+        ? cachedAtLabel == null
+              ? 'A live refresh failed, so the latest wallet snapshot remains visible.'
+              : 'A live refresh failed, so the wallet snapshot saved on $cachedAtLabel remains visible.'
+        : cachedAtLabel == null
+        ? 'Your latest saved wallet summary is being shown until connectivity returns.'
+        : 'Your wallet snapshot saved on $cachedAtLabel is being shown until connectivity returns.';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: palette.warning.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        border: Border.all(color: palette.warning.withValues(alpha: 0.28)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.wifi_off_rounded, color: palette.warning),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  message,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: palette.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/wheels/lib/shared/storage/app_hive.dart
+++ b/wheels/lib/shared/storage/app_hive.dart
@@ -3,15 +3,18 @@ import 'package:hive_flutter/hive_flutter.dart';
 class AppHiveBoxes {
   static const String rideDetailsCache = 'ride_details_cache_box_v1';
   static const String dashboardCache = 'dashboard_cache_box_v1';
+  static const String walletSummaryCache = 'wallet_summary_cache_box_v1';
 }
 
 class AppHiveKeys {
   static const String latestRideDetails = 'latest_ride_details';
   static const String latestDashboard = 'latest_dashboard';
+  static const String latestWalletSummary = 'latest_wallet_summary';
 }
 
 Future<void> initializeAppHive() async {
   await Hive.initFlutter();
   await Hive.openBox<String>(AppHiveBoxes.rideDetailsCache);
   await Hive.openBox<String>(AppHiveBoxes.dashboardCache);
+  await Hive.openBox<String>(AppHiveBoxes.walletSummaryCache);
 }


### PR DESCRIPTION
## PR Description

### Title
Add offline wallet snapshot fallback to WalletScreen

### Description
This PR adds eventual connectivity support to the wallet flow by introducing local wallet snapshot persistence in `WalletScreen`. Drivers can now keep access to their latest known wallet summary even when the device loses connectivity or a live refresh fails.

### What changed
- Added a local wallet snapshot model with `savedAt` metadata
- Added a local datasource backed by Hive to save, restore, and clear wallet snapshots
- Extended Hive initialization with a dedicated box for wallet summary cache
- Added a local datasource provider in the wallet feature
- Updated `WalletScreen` to:
  - restore the last saved wallet snapshot on startup
  - save successful live wallet responses locally
  - show cached wallet data when the device is offline
  - keep showing cached data if a live refresh fails
  - retry live loading automatically when connectivity returns
- Added a visual cached-data notice so the user knows when the wallet view is not live

### Why this matters
This improves resilience in unstable network conditions and supports the eventual connectivity requirement of the project. Drivers can still review their latest known balance and wallet summary during offline sessions instead of seeing a fully blocked screen.

### Implementation notes
- Storage strategy: Hive
- Cache format: serialized JSON snapshot
- Screen affected: `WalletScreen`
- New local persistence components:
  - `local_wallet_summary_cache_model.dart`
  - `wallet_summary_local_datasource.dart`

### Result
`WalletScreen` now behaves as an online-first screen with cached fallback, allowing the app to preserve and display the latest known wallet summary when live data is temporarily unavailable.
