### PR TITLE
Implemented withdrawal request draft

### DIFF
--- a/wheels/lib/features/wallet/data/datasources/withdrawal_request_draft_local_datasource.dart
+++ b/wheels/lib/features/wallet/data/datasources/withdrawal_request_draft_local_datasource.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../../../../shared/storage/app_hive.dart';
+import '../models/local_withdrawal_request_draft_model.dart';
+
+LocalWithdrawalRequestDraftModel _decodeWithdrawalDraft(String rawCache) {
+  final decoded = jsonDecode(rawCache);
+  if (decoded is! Map) {
+    throw const FormatException('Stored withdrawal draft is invalid.');
+  }
+
+  return LocalWithdrawalRequestDraftModel.fromJson(
+    Map<String, dynamic>.from(decoded),
+  );
+}
+
+String _encodeWithdrawalDraft(LocalWithdrawalRequestDraftModel draft) {
+  return jsonEncode(draft.toJson());
+}
+
+class WithdrawalRequestDraftLocalDataSource {
+  const WithdrawalRequestDraftLocalDataSource();
+
+  Future<LocalWithdrawalRequestDraftModel?> loadDraft({
+    required String cacheId,
+  }) async {
+    final box = Hive.box<String>(AppHiveBoxes.withdrawalRequestDrafts);
+    final rawCache = box.get(cacheId);
+    if (rawCache == null || rawCache.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      return await compute(_decodeWithdrawalDraft, rawCache);
+    } catch (_) {
+      await clearDraft(cacheId: cacheId);
+      return null;
+    }
+  }
+
+  Future<void> saveDraft({
+    required String cacheId,
+    required LocalWithdrawalRequestDraftModel draft,
+  }) async {
+    final encoded = await compute(_encodeWithdrawalDraft, draft);
+    final box = Hive.box<String>(AppHiveBoxes.withdrawalRequestDrafts);
+    await box.put(cacheId, encoded);
+  }
+
+  Future<void> clearDraft({required String cacheId}) async {
+    final box = Hive.box<String>(AppHiveBoxes.withdrawalRequestDrafts);
+    await box.delete(cacheId);
+  }
+}

--- a/wheels/lib/features/wallet/data/models/local_withdrawal_request_draft_model.dart
+++ b/wheels/lib/features/wallet/data/models/local_withdrawal_request_draft_model.dart
@@ -1,0 +1,89 @@
+class LocalWithdrawalRequestDraftModel {
+  const LocalWithdrawalRequestDraftModel({
+    required this.version,
+    required this.savedAt,
+    required this.amountText,
+    required this.bankName,
+    required this.accountType,
+    required this.accountNumber,
+    required this.accountHolderName,
+  });
+
+  final int version;
+  final DateTime savedAt;
+  final String amountText;
+  final String bankName;
+  final String accountType;
+  final String accountNumber;
+  final String accountHolderName;
+
+  factory LocalWithdrawalRequestDraftModel.create({
+    required String amountText,
+    required String bankName,
+    required String accountType,
+    required String accountNumber,
+    required String accountHolderName,
+    DateTime? savedAt,
+  }) {
+    return LocalWithdrawalRequestDraftModel(
+      version: 1,
+      savedAt: savedAt ?? DateTime.now(),
+      amountText: amountText,
+      bankName: bankName,
+      accountType: accountType,
+      accountNumber: accountNumber,
+      accountHolderName: accountHolderName,
+    );
+  }
+
+  factory LocalWithdrawalRequestDraftModel.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final version = (json['version'] as num?)?.toInt() ?? 1;
+    if (version != 1) {
+      throw FormatException('Unsupported withdrawal draft version: $version');
+    }
+
+    final savedAtRaw = json['savedAt'];
+    if (savedAtRaw is! String) {
+      throw const FormatException(
+        'Stored withdrawal draft has an invalid saved date.',
+      );
+    }
+
+    final savedAt = DateTime.tryParse(savedAtRaw);
+    if (savedAt == null) {
+      throw const FormatException(
+        'Stored withdrawal draft has an invalid saved date.',
+      );
+    }
+
+    return LocalWithdrawalRequestDraftModel(
+      version: version,
+      savedAt: savedAt,
+      amountText: (json['amountText'] as String?) ?? '',
+      bankName: (json['bankName'] as String?) ?? '',
+      accountType: (json['accountType'] as String?) ?? 'savings',
+      accountNumber: (json['accountNumber'] as String?) ?? '',
+      accountHolderName: (json['accountHolderName'] as String?) ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'version': version,
+      'savedAt': savedAt.toIso8601String(),
+      'amountText': amountText,
+      'bankName': bankName,
+      'accountType': accountType,
+      'accountNumber': accountNumber,
+      'accountHolderName': accountHolderName,
+    };
+  }
+
+  bool get hasMeaningfulData =>
+      amountText.trim().isNotEmpty ||
+      bankName.trim().isNotEmpty ||
+      accountNumber.trim().isNotEmpty ||
+      accountHolderName.trim().isNotEmpty;
+}

--- a/wheels/lib/features/wallet/presentation/providers/wallet_providers.dart
+++ b/wheels/lib/features/wallet/presentation/providers/wallet_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/withdrawal_request_draft_local_datasource.dart';
 import '../../data/datasources/wallet_remote_datasource.dart';
 import '../../data/repositories/wallet_repository_impl.dart';
 import '../../domain/entities/withdrawal_request_input.dart';
@@ -10,6 +11,11 @@ import '../../domain/repositories/wallet_repository.dart';
 final walletRemoteDataSourceProvider = Provider<WalletRemoteDataSource>((ref) {
   return WalletRemoteDataSource();
 });
+
+final withdrawalRequestDraftLocalDataSourceProvider =
+    Provider<WithdrawalRequestDraftLocalDataSource>((ref) {
+      return const WithdrawalRequestDraftLocalDataSource();
+    });
 
 final walletRepositoryProvider = Provider<WalletRepository>((ref) {
   return WalletRepositoryImpl(

--- a/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
+++ b/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../shared/providers/connectivity_provider.dart';
 import '../../../../shared/ui/app_scaffold.dart';
 import '../../../../shared/utils/app_formatter.dart';
 import '../../../../shared/widgets/app_button.dart';
@@ -10,6 +13,7 @@ import '../../../../theme/app_radius.dart';
 import '../../../../theme/app_spacing.dart';
 import '../../../../theme/app_theme_palette.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/models/local_withdrawal_request_draft_model.dart';
 import '../../domain/entities/withdrawal_request_input.dart';
 import '../../domain/entities/wallet_summary.dart';
 import '../providers/wallet_providers.dart';
@@ -29,15 +33,162 @@ class _WithdrawalRequestScreenState
   final _bankNameController = TextEditingController();
   final _accountNumberController = TextEditingController();
   final _accountHolderNameController = TextEditingController();
+  Timer? _draftSaveDebounce;
   String _accountType = 'savings';
+  bool _isDraftLoaded = false;
+  bool _draftRestored = false;
+  DateTime? _draftSavedAt;
+
+  String get _draftCacheId {
+    final user = ref.read(authUserProvider);
+    return user == null
+        ? 'anonymous_withdrawal_request'
+        : 'withdrawal_request_${user.uid}';
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _amountController.addListener(_onDraftChanged);
+    _bankNameController.addListener(_onDraftChanged);
+    _accountNumberController.addListener(_onDraftChanged);
+    _accountHolderNameController.addListener(_onDraftChanged);
+    Future<void>.microtask(_restoreDraftIfAvailable);
+  }
 
   @override
   void dispose() {
+    _draftSaveDebounce?.cancel();
+    _amountController.removeListener(_onDraftChanged);
+    _bankNameController.removeListener(_onDraftChanged);
+    _accountNumberController.removeListener(_onDraftChanged);
+    _accountHolderNameController.removeListener(_onDraftChanged);
     _amountController.dispose();
     _bankNameController.dispose();
     _accountNumberController.dispose();
     _accountHolderNameController.dispose();
     super.dispose();
+  }
+
+  void _onDraftChanged() {
+    if (!_isDraftLoaded) {
+      return;
+    }
+
+    _scheduleDraftSave();
+  }
+
+  void _scheduleDraftSave() {
+    _draftSaveDebounce?.cancel();
+    _draftSaveDebounce = Timer(const Duration(milliseconds: 350), () {
+      unawaited(_persistDraft());
+    });
+  }
+
+  LocalWithdrawalRequestDraftModel _buildDraftSnapshot() {
+    return LocalWithdrawalRequestDraftModel.create(
+      amountText: _amountController.text,
+      bankName: _bankNameController.text,
+      accountType: _accountType,
+      accountNumber: _accountNumberController.text,
+      accountHolderName: _accountHolderNameController.text,
+    );
+  }
+
+  Future<void> _restoreDraftIfAvailable() async {
+    final draft = await ref
+        .read(withdrawalRequestDraftLocalDataSourceProvider)
+        .loadDraft(cacheId: _draftCacheId);
+
+    if (!mounted) {
+      return;
+    }
+
+    if (draft != null && draft.hasMeaningfulData) {
+      _amountController.text = draft.amountText;
+      _bankNameController.text = draft.bankName;
+      _accountNumberController.text = draft.accountNumber;
+      _accountHolderNameController.text = draft.accountHolderName;
+      _accountType = draft.accountType;
+    }
+
+    setState(() {
+      _isDraftLoaded = true;
+      _draftRestored = draft != null && draft.hasMeaningfulData;
+      _draftSavedAt = draft?.savedAt;
+    });
+  }
+
+  Future<void> _persistDraft({bool showFeedback = false}) async {
+    final draft = _buildDraftSnapshot();
+    if (!draft.hasMeaningfulData) {
+      await _clearDraft(showFeedback: false);
+      return;
+    }
+
+    await ref
+        .read(withdrawalRequestDraftLocalDataSourceProvider)
+        .saveDraft(cacheId: _draftCacheId, draft: draft);
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _draftSavedAt = draft.savedAt;
+    });
+
+    if (showFeedback) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(content: Text('Withdrawal form draft saved locally.')),
+        );
+    }
+  }
+
+  Future<void> _clearDraft({bool showFeedback = false}) async {
+    await ref
+        .read(withdrawalRequestDraftLocalDataSourceProvider)
+        .clearDraft(cacheId: _draftCacheId);
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _draftRestored = false;
+      _draftSavedAt = null;
+    });
+
+    if (showFeedback) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(content: Text('Withdrawal form draft cleared.')),
+        );
+    }
+  }
+
+  void _resetForm() {
+    _amountController.clear();
+    _bankNameController.clear();
+    _accountNumberController.clear();
+    _accountHolderNameController.clear();
+    if (mounted) {
+      setState(() {
+        _accountType = 'savings';
+      });
+    } else {
+      _accountType = 'savings';
+    }
+    _formKey.currentState?.reset();
+  }
+
+  String _formatDraftSavedAt(DateTime savedAt) {
+    final date = '${savedAt.day}/${savedAt.month}/${savedAt.year}';
+    final hour = TimeOfDay.fromDateTime(savedAt).format(context);
+    return '$date at $hour';
   }
 
   @override
@@ -58,6 +209,8 @@ class _WithdrawalRequestScreenState
             }
 
             ref.read(withdrawalRequestControllerProvider.notifier).clear();
+            unawaited(_clearDraft(showFeedback: false));
+            _resetForm();
             ScaffoldMessenger.of(context)
               ..hideCurrentSnackBar()
               ..showSnackBar(
@@ -99,6 +252,21 @@ class _WithdrawalRequestScreenState
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    if (_draftRestored && _draftSavedAt != null) ...[
+                      _DraftNoticeCard(
+                        savedAtLabel: _formatDraftSavedAt(_draftSavedAt!),
+                        onSaveNow: isLoading
+                            ? null
+                            : () => _persistDraft(showFeedback: true),
+                        onDiscard: isLoading
+                            ? null
+                            : () async {
+                                _resetForm();
+                                await _clearDraft(showFeedback: true);
+                              },
+                      ),
+                      const SizedBox(height: AppSpacing.l),
+                    ],
                     _WithdrawalInfoCard(walletSummary: walletSummary),
                     const SizedBox(height: AppSpacing.l),
                     _FormTextField(
@@ -150,6 +318,7 @@ class _WithdrawalRequestScreenState
                           : (value) {
                               if (value != null) {
                                 setState(() => _accountType = value);
+                                _scheduleDraftSave();
                               }
                             },
                     ),
@@ -211,6 +380,27 @@ class _WithdrawalRequestScreenState
       return;
     }
 
+    final hasConnection = await ref
+        .read(connectivityServiceProvider)
+        .hasConnection();
+    if (!hasConnection) {
+      await _persistDraft(showFeedback: false);
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(
+            content: Text(
+              'You need an internet connection to submit a withdrawal request. Your draft was saved locally.',
+            ),
+          ),
+        );
+      return;
+    }
+
     final amount = _parseAmount(_amountController.text);
     if (amount == null) {
       return;
@@ -253,6 +443,69 @@ class _WithdrawalRequestScreenState
       focusedBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(AppRadius.md),
         borderSide: BorderSide(color: palette.primary),
+      ),
+    );
+  }
+}
+
+class _DraftNoticeCard extends StatelessWidget {
+  const _DraftNoticeCard({
+    required this.savedAtLabel,
+    required this.onSaveNow,
+    required this.onDiscard,
+  });
+
+  final String savedAtLabel;
+  final VoidCallback? onSaveNow;
+  final VoidCallback? onDiscard;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: palette.warning.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        border: Border.all(color: palette.warning.withValues(alpha: 0.24)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Restored local withdrawal draft',
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              color: palette.textPrimary,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            'The form data saved on $savedAtLabel was restored so you can continue where you left off.',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: palette.textSecondary,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Wrap(
+            spacing: AppSpacing.s,
+            runSpacing: AppSpacing.s,
+            children: [
+              OutlinedButton.icon(
+                onPressed: onSaveNow,
+                icon: const Icon(Icons.save_outlined),
+                label: const Text('Save Draft'),
+              ),
+              OutlinedButton.icon(
+                onPressed: onDiscard,
+                icon: const Icon(Icons.delete_outline_rounded),
+                label: const Text('Discard Draft'),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/wheels/lib/shared/storage/app_hive.dart
+++ b/wheels/lib/shared/storage/app_hive.dart
@@ -3,6 +3,8 @@ import 'package:hive_flutter/hive_flutter.dart';
 class AppHiveBoxes {
   static const String rideDetailsCache = 'ride_details_cache_box_v1';
   static const String dashboardCache = 'dashboard_cache_box_v1';
+  static const String withdrawalRequestDrafts =
+      'withdrawal_request_drafts_box_v1';
 }
 
 class AppHiveKeys {
@@ -14,4 +16,5 @@ Future<void> initializeAppHive() async {
   await Hive.initFlutter();
   await Hive.openBox<String>(AppHiveBoxes.rideDetailsCache);
   await Hive.openBox<String>(AppHiveBoxes.dashboardCache);
+  await Hive.openBox<String>(AppHiveBoxes.withdrawalRequestDrafts);
 }


### PR DESCRIPTION
## PR Description

### Title
Add local draft persistence to Withdrawal Request screen

### Description
This PR adds eventual connectivity support to `WithdrawalRequestScreen` by introducing local draft persistence for the withdrawal form. Drivers can now keep their progress while filling out the form, recover it after leaving the screen, and avoid losing information when connectivity is unavailable at submission time.

### What changed
- Added a local draft model for withdrawal request form data
- Added a local datasource backed by Hive to save, restore, and clear withdrawal drafts
- Extended Hive initialization with a dedicated box for withdrawal request drafts
- Added a local datasource provider in the wallet feature
- Updated `WithdrawalRequestScreen` to:
  - restore the latest saved draft on startup
  - autosave form progress while the user edits the screen
  - show a visual notice when a draft has been restored
  - allow the user to save or discard the restored draft manually
  - keep the draft if the user tries to submit without internet
  - clear the draft after a successful submission

### Why this matters
This improves resilience in unstable network conditions and supports the eventual connectivity requirement of the project. Users no longer lose withdrawal form progress during offline or interrupted sessions, while the final financial submission remains online-only for consistency and safety.

### Implementation notes
- Storage strategy: Hive
- Cache format: serialized JSON snapshot
- Screen affected: `WithdrawalRequestScreen`
- New local persistence components:
  - `local_withdrawal_request_draft_model.dart`
  - `withdrawal_request_draft_local_datasource.dart`

### Scope decision
Only the withdrawal form draft is persisted locally. The final withdrawal submission still requires internet connection, since financial operations should not be committed offline.

### Result
`WithdrawalRequestScreen` now behaves as a draft-capable, online-only submission flow: form progress is preserved locally, restored automatically, and only sent to the backend when live connectivity is available.
