### PR TITLE
Implemented offline persistence tests

### DIFF
--- a/wheels/lib/features/rides/presentation/screens/active_ride_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/active_ride_screen.dart
@@ -323,10 +323,6 @@ class ActiveRideScreen extends ConsumerWidget {
       }
 
       for (final application in applications) {
-        if (application.usesCardPayment) {
-          continue;
-        }
-
         final reviewedStatus =
             review.paymentStatuses[application.id] ??
             RidePassengerPaymentStatus.pending;
@@ -347,7 +343,7 @@ class ActiveRideScreen extends ConsumerWidget {
             .read(ridePaymentControllerProvider.notifier)
             .updatePassengerPaymentStatus(
               rideId: ride.id,
-              passengerId: application.id,
+              passengerId: application.passengerId,
               paymentMethod: paymentMethod,
               paymentStatus: finalPaymentStatus,
               isPaymentLocked: true,
@@ -358,7 +354,7 @@ class ActiveRideScreen extends ConsumerWidget {
       ref.read(ridePaymentControllerProvider.notifier).clear();
       await updateStatus(
         'completed',
-        'Ride finished and manual payment statuses were saved.',
+        'Ride finished and passenger payment statuses were saved.',
       );
     }
 
@@ -618,7 +614,7 @@ class ActiveRideScreen extends ConsumerWidget {
                     SizedBox(
                       width: double.infinity,
                       child: OutlinedButton(
-                        onPressed: () => Navigator.of(context).pop(false),
+                        onPressed: () => Navigator.of(context).pop(),
                         child: const Text('Go Back'),
                       ),
                     ),

--- a/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
+++ b/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
@@ -44,7 +44,7 @@ class _WithdrawalRequestScreenState
   Widget build(BuildContext context) {
     final currentUser = ref.watch(authUserProvider);
     final role = ref.watch(currentUserRoleProvider);
-    final walletSummary = ref.watch(driverWalletSummaryProvider).valueOrNull;
+    final walletSummaryAsync = ref.watch(driverWalletSummaryProvider);
     final requestState = ref.watch(withdrawalRequestControllerProvider);
     final isLoading = requestState.isLoading;
 
@@ -93,126 +93,159 @@ class _WithdrawalRequestScreenState
       title: 'Request Withdrawal',
       child: currentUser == null || role != UserRole.driver
           ? const _WithdrawalAccessCard()
-          : SingleChildScrollView(
-              child: Form(
-                key: _formKey,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _WithdrawalInfoCard(walletSummary: walletSummary),
-                    const SizedBox(height: AppSpacing.l),
-                    _FormTextField(
-                      controller: _amountController,
-                      label: 'Amount',
-                      hintText: '10000',
-                      keyboardType: TextInputType.number,
-                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                      validator: (value) {
-                        final amount = _parseAmount(value);
-                        if (amount == null) {
-                          return 'Enter a valid amount.';
-                        }
-                        if (amount < walletMinimumWithdrawalAmountCop) {
-                          return 'Minimum withdrawal is COP 10.000.';
-                        }
-                        return null;
-                      },
-                    ),
-                    const SizedBox(height: AppSpacing.m),
-                    _FormTextField(
-                      controller: _bankNameController,
-                      label: 'Bank name',
-                      hintText: 'Bancolombia',
-                      textCapitalization: TextCapitalization.words,
-                      validator: (value) {
-                        if (value == null || value.trim().isEmpty) {
-                          return 'Enter the bank name.';
-                        }
-                        return null;
-                      },
-                    ),
-                    const SizedBox(height: AppSpacing.m),
-                    DropdownButtonFormField<String>(
-                      initialValue: _accountType,
-                      decoration: _inputDecoration('Account type'),
-                      items: const [
-                        DropdownMenuItem(
-                          value: 'savings',
-                          child: Text('Savings'),
+          : walletSummaryAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) => _WithdrawalLoadErrorCard(
+                message: error.toString().replaceFirst('Exception: ', ''),
+                onRetry: () => ref.invalidate(driverWalletSummaryProvider),
+              ),
+              data: (walletSummary) {
+                if (walletSummary == null) {
+                  return const _WithdrawalAccessCard();
+                }
+
+                return SingleChildScrollView(
+                  child: Form(
+                    key: _formKey,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _WithdrawalInfoCard(walletSummary: walletSummary),
+                        const SizedBox(height: AppSpacing.l),
+                        _FormTextField(
+                          controller: _amountController,
+                          label: 'Amount',
+                          hintText: '10000',
+                          keyboardType: TextInputType.number,
+                          inputFormatters: [
+                            FilteringTextInputFormatter.digitsOnly,
+                          ],
+                          validator: (value) {
+                            final amount = _parseAmount(value);
+                            if (amount == null) {
+                              return 'Enter a valid amount.';
+                            }
+                            if (amount < walletMinimumWithdrawalAmountCop) {
+                              return 'Minimum withdrawal is COP 10.000.';
+                            }
+                            if (amount > walletSummary.availableBalance) {
+                              return 'Amount exceeds your available balance.';
+                            }
+                            return null;
+                          },
                         ),
-                        DropdownMenuItem(
-                          value: 'checking',
-                          child: Text('Checking'),
+                        const SizedBox(height: AppSpacing.m),
+                        _FormTextField(
+                          controller: _bankNameController,
+                          label: 'Bank name',
+                          hintText: 'Bancolombia',
+                          textCapitalization: TextCapitalization.words,
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Enter the bank name.';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: AppSpacing.m),
+                        DropdownButtonFormField<String>(
+                          initialValue: _accountType,
+                          decoration: _inputDecoration('Account type'),
+                          items: const [
+                            DropdownMenuItem(
+                              value: 'savings',
+                              child: Text('Savings'),
+                            ),
+                            DropdownMenuItem(
+                              value: 'checking',
+                              child: Text('Checking'),
+                            ),
+                          ],
+                          onChanged: isLoading
+                              ? null
+                              : (value) {
+                                  if (value != null) {
+                                    setState(() => _accountType = value);
+                                  }
+                                },
+                        ),
+                        const SizedBox(height: AppSpacing.m),
+                        _FormTextField(
+                          controller: _accountNumberController,
+                          label: 'Account number',
+                          hintText: '0123456789',
+                          keyboardType: TextInputType.number,
+                          inputFormatters: [
+                            FilteringTextInputFormatter.digitsOnly,
+                          ],
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Enter the account number.';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: AppSpacing.m),
+                        _FormTextField(
+                          controller: _accountHolderNameController,
+                          label: 'Account holder name',
+                          hintText: 'Full legal name',
+                          textCapitalization: TextCapitalization.words,
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Enter the account holder name.';
+                            }
+                            return null;
+                          },
+                        ),
+                        if (isLoading) ...[
+                          const SizedBox(height: AppSpacing.m),
+                          const LinearProgressIndicator(),
+                        ],
+                        const SizedBox(height: AppSpacing.l),
+                        AppButton(
+                          label: isLoading
+                              ? 'Submitting withdrawal...'
+                              : 'Submit withdrawal request',
+                          onPressed: isLoading || !walletSummary.canRequestWithdrawal
+                              ? null
+                              : () => _submit(userId: currentUser.uid, walletSummary: walletSummary),
+                        ),
+                        const SizedBox(height: AppSpacing.s),
+                        AppButton(
+                          label: 'Back',
+                          onPressed: isLoading ? null : () => context.pop(),
+                          isPrimary: false,
                         ),
                       ],
-                      onChanged: isLoading
-                          ? null
-                          : (value) {
-                              if (value != null) {
-                                setState(() => _accountType = value);
-                              }
-                            },
                     ),
-                    const SizedBox(height: AppSpacing.m),
-                    _FormTextField(
-                      controller: _accountNumberController,
-                      label: 'Account number',
-                      hintText: '0123456789',
-                      keyboardType: TextInputType.number,
-                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                      validator: (value) {
-                        if (value == null || value.trim().isEmpty) {
-                          return 'Enter the account number.';
-                        }
-                        return null;
-                      },
-                    ),
-                    const SizedBox(height: AppSpacing.m),
-                    _FormTextField(
-                      controller: _accountHolderNameController,
-                      label: 'Account holder name',
-                      hintText: 'Full legal name',
-                      textCapitalization: TextCapitalization.words,
-                      validator: (value) {
-                        if (value == null || value.trim().isEmpty) {
-                          return 'Enter the account holder name.';
-                        }
-                        return null;
-                      },
-                    ),
-                    if (isLoading) ...[
-                      const SizedBox(height: AppSpacing.m),
-                      const LinearProgressIndicator(),
-                    ],
-                    const SizedBox(height: AppSpacing.l),
-                    AppButton(
-                      label: isLoading
-                          ? 'Submitting withdrawal...'
-                          : 'Submit withdrawal request',
-                      onPressed: isLoading
-                          ? null
-                          : () => _submit(currentUser.uid),
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    AppButton(
-                      label: 'Back',
-                      onPressed: isLoading ? null : () => context.pop(),
-                      isPrimary: false,
-                    ),
-                  ],
-                ),
-              ),
+                  ),
+                );
+              },
             ),
     );
   }
 
-  Future<void> _submit(String userId) async {
+  Future<void> _submit({
+    required String userId,
+    required WalletSummary walletSummary,
+  }) async {
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
     }
 
     final amount = _parseAmount(_amountController.text);
     if (amount == null) {
+      return;
+    }
+    if (amount > walletSummary.availableBalance) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(
+            content: Text('Amount exceeds your available balance.'),
+          ),
+        );
       return;
     }
 
@@ -389,6 +422,58 @@ class _WithdrawalAccessCard extends StatelessWidget {
                 context,
               ).textTheme.bodyMedium?.copyWith(color: palette.textSecondary),
             ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WithdrawalLoadErrorCard extends StatelessWidget {
+  const _WithdrawalLoadErrorCard({
+    required this.message,
+    required this.onRetry,
+  });
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+
+    return Center(
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(AppSpacing.l),
+        decoration: BoxDecoration(
+          color: palette.card,
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+          border: Border.all(color: palette.border),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline_rounded, color: palette.error),
+            const SizedBox(height: AppSpacing.m),
+            Text(
+              'We could not load the wallet balance.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: palette.primary,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(color: palette.textSecondary),
+            ),
+            const SizedBox(height: AppSpacing.m),
+            AppButton(label: 'Retry', onPressed: onRetry),
           ],
         ),
       ),

--- a/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
+++ b/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
@@ -234,6 +234,28 @@ class _WithdrawalRequestScreenState
       return;
     }
 
+    final hasConnection = await ref
+        .read(connectivityServiceProvider)
+        .hasConnection();
+    if (!hasConnection) {
+      await _persistDraft(showFeedback: false);
+
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(
+            content: Text(
+              'You need an internet connection to submit a withdrawal request. Your draft was saved locally.',
+            ),
+          ),
+        );
+      return;
+    }
+
     final amount = _parseAmount(_amountController.text);
     if (amount == null) {
       return;

--- a/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
+++ b/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
@@ -288,7 +288,7 @@ class _WithdrawalRequestScreenState
                           label: 'Amount',
                           hintText: '10000',
                           keyboardType: TextInputType.number,
-                          inputFormatters: const [
+                          inputFormatters: [
                             FilteringTextInputFormatter.digitsOnly,
                           ],
                           validator: (value) {
@@ -349,7 +349,7 @@ class _WithdrawalRequestScreenState
                           label: 'Account number',
                           hintText: '0123456789',
                           keyboardType: TextInputType.number,
-                          inputFormatters: const [
+                          inputFormatters: [
                             FilteringTextInputFormatter.digitsOnly,
                           ],
                           validator: (value) {

--- a/wheels/test/features/rides/data/datasources/ride_details_local_datasource_test.dart
+++ b/wheels/test/features/rides/data/datasources/ride_details_local_datasource_test.dart
@@ -40,6 +40,7 @@ void main() {
   });
 
   setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
     memoryCache = MemoryLruCache<String, LocalRideDetailsCacheModel>(
       maxEntries: 4,
     );

--- a/wheels/test/features/rides/data/datasources/ride_details_local_datasource_test.dart
+++ b/wheels/test/features/rides/data/datasources/ride_details_local_datasource_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wheels/features/rides/data/datasources/ride_details_local_datasource.dart';
+import 'package:wheels/features/rides/data/models/local_ride_details_cache_model.dart';
+import 'package:wheels/shared/cache/memory_lru_cache.dart';
+import 'package:wheels/shared/storage/app_hive.dart';
+
+import '../../../../support/ride_test_data.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const legacyPrefsKey = 'ride_details_cache_v1';
+  late Directory hiveDirectory;
+  late Box<String> rideDetailsBox;
+  late MemoryLruCache<String, LocalRideDetailsCacheModel> memoryCache;
+  late RideDetailsLocalDataSource dataSource;
+
+  setUpAll(() async {
+    hiveDirectory = await Directory.systemTemp.createTemp('ride-details-test');
+    Hive.init(hiveDirectory.path);
+    rideDetailsBox = await Hive.openBox<String>(AppHiveBoxes.rideDetailsCache);
+  });
+
+  tearDown(() async {
+    await rideDetailsBox.clear();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    memoryCache.clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (hiveDirectory.existsSync()) {
+      await hiveDirectory.delete(recursive: true);
+    }
+  });
+
+  setUp(() {
+    memoryCache = MemoryLruCache<String, LocalRideDetailsCacheModel>(
+      maxEntries: 4,
+    );
+    dataSource = RideDetailsLocalDataSource(
+      memoryCache: memoryCache,
+    );
+  });
+
+  group('RideDetailsLocalDataSource', () {
+    test('returns null when there is no cache in memory, hive, or prefs', () async {
+      final restored = await dataSource.loadRideDetails('ride-1');
+
+      expect(restored, isNull);
+    });
+
+    test('saves to Hive and restores ride details', () async {
+      final cache = buildRideDetailsCache(rideId: 'ride-1');
+
+      await dataSource.saveRideDetails(cache);
+      memoryCache.clear();
+
+      final restored = await dataSource.loadRideDetails('ride-1');
+
+      expect(restored, isNotNull);
+      expect(restored!.rideId, 'ride-1');
+      expect(restored.toEntity().driverName, 'Martin Driver');
+      expect(rideDetailsBox.get('ride-1'), isNotNull);
+    });
+
+    test('returns the memory cache hit before checking Hive', () async {
+      final cache = buildRideDetailsCache(rideId: 'ride-memory');
+      memoryCache.put('ride-memory', cache);
+
+      final restored = await dataSource.loadRideDetails('ride-memory');
+
+      expect(restored, same(cache));
+    });
+
+    test('clears invalid Hive cache entries and returns null', () async {
+      await rideDetailsBox.put('ride-1', '{"bad":');
+
+      final restored = await dataSource.loadRideDetails('ride-1');
+
+      expect(restored, isNull);
+      expect(rideDetailsBox.get('ride-1'), isNull);
+    });
+
+    test('migrates legacy shared preferences cache into Hive storage', () async {
+      final legacyCache = buildRideDetailsCache(rideId: 'ride-legacy');
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        legacyPrefsKey: jsonEncode(legacyCache.toJson()),
+      });
+
+      final restored = await dataSource.loadRideDetails('ride-legacy');
+      final prefs = await SharedPreferences.getInstance();
+
+      expect(restored, isNotNull);
+      expect(restored!.rideId, 'ride-legacy');
+      expect(rideDetailsBox.get('ride-legacy'), isNotNull);
+      expect(prefs.getString(legacyPrefsKey), isNull);
+    });
+
+    test('drops legacy cache if it belongs to a different ride', () async {
+      final legacyCache = buildRideDetailsCache(rideId: 'ride-legacy');
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        legacyPrefsKey: jsonEncode(legacyCache.toJson()),
+      });
+
+      final restored = await dataSource.loadRideDetails('other-ride');
+      final prefs = await SharedPreferences.getInstance();
+
+      expect(restored, isNull);
+      expect(prefs.getString(legacyPrefsKey), isNull);
+      expect(rideDetailsBox.values, isEmpty);
+    });
+
+    test('loadLatestRideDetails restores only the legacy shared preferences cache', () async {
+      final legacyCache = buildRideDetailsCache(rideId: 'ride-latest');
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        legacyPrefsKey: jsonEncode(legacyCache.toJson()),
+      });
+
+      final restored = await dataSource.loadLatestRideDetails();
+
+      expect(restored, isNotNull);
+      expect(restored!.rideId, 'ride-latest');
+    });
+
+    test('clearRideDetails removes both Hive and in-memory cache entries', () async {
+      final cache = buildRideDetailsCache(rideId: 'ride-clear');
+      await dataSource.saveRideDetails(cache);
+
+      expect(memoryCache.containsKey('ride-clear'), isTrue);
+      expect(rideDetailsBox.get('ride-clear'), isNotNull);
+
+      await dataSource.clearRideDetails('ride-clear');
+
+      expect(memoryCache.containsKey('ride-clear'), isFalse);
+      expect(rideDetailsBox.get('ride-clear'), isNull);
+    });
+  });
+}

--- a/wheels/test/features/rides/data/datasources/rides_search_local_datasource_test.dart
+++ b/wheels/test/features/rides/data/datasources/rides_search_local_datasource_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wheels/features/rides/data/datasources/rides_search_local_datasource.dart';
+
+import '../../../../support/ride_test_data.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const cacheKey = 'rides_search_cache_v1';
+  late RidesSearchLocalDataSource dataSource;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    dataSource = RidesSearchLocalDataSource();
+  });
+
+  group('RidesSearchLocalDataSource', () {
+    test('returns null when there is no cached search', () async {
+      final result = await dataSource.loadLatestSearch();
+
+      expect(result, isNull);
+    });
+
+    test('saves and restores the latest search cache', () async {
+      final cache = buildSearchCache();
+
+      await dataSource.saveLatestSearch(cache);
+      final restored = await dataSource.loadLatestSearch();
+
+      expect(restored, isNotNull);
+      expect(restored!.filters.originQuery, cache.filters.originQuery);
+      expect(restored.filters.destinationQuery, cache.filters.destinationQuery);
+      expect(restored.filters.sort, cache.filters.sort);
+      expect(restored.results.map((ride) => ride.id), <String>['ride-1', 'ride-2']);
+    });
+
+    test('returns null and clears storage when cached payload is invalid', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        cacheKey: '{"version":1,"savedAt":"oops"',
+      });
+
+      final restored = await dataSource.loadLatestSearch();
+      final prefs = await SharedPreferences.getInstance();
+
+      expect(restored, isNull);
+      expect(prefs.getString(cacheKey), isNull);
+    });
+
+    test('clearLatestSearch removes a previously saved cache', () async {
+      final cache = buildSearchCache();
+      await dataSource.saveLatestSearch(cache);
+
+      await dataSource.clearLatestSearch();
+      final restored = await dataSource.loadLatestSearch();
+
+      expect(restored, isNull);
+    });
+
+    test('returns null for blank stored strings', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{cacheKey: '   '});
+
+      final restored = await dataSource.loadLatestSearch();
+
+      expect(restored, isNull);
+    });
+  });
+}

--- a/wheels/test/features/rides/data/models/local_ride_details_cache_model_test.dart
+++ b/wheels/test/features/rides/data/models/local_ride_details_cache_model_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wheels/features/rides/data/models/local_ride_details_cache_model.dart';
+
+import '../../../../support/ride_test_data.dart';
+
+void main() {
+  group('LocalRideDetailsCacheModel', () {
+    test('round-trips through json and restores the ride entity', () {
+      final cache = buildRideDetailsCache();
+
+      final restored = LocalRideDetailsCacheModel.fromJson(cache.toJson());
+      final entity = restored.toEntity();
+
+      expect(restored.version, LocalRideDetailsCacheModel.currentVersion);
+      expect(restored.rideId, 'ride-1');
+      expect(entity.id, 'ride-1');
+      expect(entity.origin, 'Uniandes');
+      expect(entity.destination, 'Cedritos');
+      expect(entity.driverRating, 4.8);
+    });
+
+    test('throws when rideId does not match stored ride payload', () {
+      final invalidJson = buildRideDetailsCache().toJson()
+        ..['rideId'] = 'different-ride';
+
+      expect(
+        () => LocalRideDetailsCacheModel.fromJson(invalidJson),
+        throwsFormatException,
+      );
+    });
+
+    test('matchesRide only returns true for the cached ride id', () {
+      final cache = buildRideDetailsCache(rideId: 'ride-42');
+
+      expect(cache.matchesRide('ride-42'), isTrue);
+      expect(cache.matchesRide('ride-99'), isFalse);
+    });
+
+    test('isExpired returns true for very old cache entries', () {
+      final oldCache = buildRideDetailsCache(
+        savedAt: DateTime.now().toUtc().subtract(const Duration(hours: 7)),
+      );
+
+      expect(oldCache.isExpired(), isTrue);
+    });
+
+    test('isExpired returns true for future timestamps beyond tolerance', () {
+      final futureCache = buildRideDetailsCache(
+        savedAt: DateTime.now().toUtc().add(const Duration(minutes: 10)),
+      );
+
+      expect(futureCache.isExpired(), isTrue);
+    });
+
+    test('isExpired returns false for recent cache entries', () {
+      final freshCache = buildRideDetailsCache(
+        savedAt: DateTime.now().toUtc().subtract(const Duration(minutes: 15)),
+      );
+
+      expect(freshCache.isExpired(), isFalse);
+    });
+  });
+}

--- a/wheels/test/features/rides/data/models/local_ride_search_cache_model_test.dart
+++ b/wheels/test/features/rides/data/models/local_ride_search_cache_model_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wheels/features/rides/data/models/local_ride_search_cache_model.dart';
+import 'package:wheels/features/rides/domain/entities/rides_entity.dart';
+import 'package:wheels/features/rides/presentation/models/ride_listing.dart';
+
+import '../../../../support/ride_test_data.dart';
+
+void main() {
+  group('LocalRideSearchFiltersModel', () {
+    test('serializes selectedDate as a date-only value', () {
+      final filters = buildSearchFilters(
+        selectedDate: DateTime.utc(2026, 4, 24, 18, 45),
+        sort: RideSortOption.cheapest,
+      );
+
+      final json = filters.toJson();
+
+      expect(json['selectedDate'], '2026-04-24');
+      expect(json['sort'], 'cheapest');
+    });
+
+    test('normalizes selectedDate when reading from json', () {
+      final filters = LocalRideSearchFiltersModel.fromJson(<String, dynamic>{
+        'originQuery': 'Uniandes',
+        'destinationQuery': 'Chapinero',
+        'selectedDate': '2026-04-24T19:30:00.000Z',
+        'sort': 'highestRated',
+      });
+
+      expect(filters.selectedDate, DateTime(2026, 4, 24));
+      expect(filters.sort, RideSortOption.highestRated);
+    });
+
+    test('throws when sort value is unsupported', () {
+      expect(
+        () => LocalRideSearchFiltersModel.fromJson(<String, dynamic>{
+          'originQuery': 'Uniandes',
+          'destinationQuery': 'Cedritos',
+          'selectedDate': '2026-04-24',
+          'sort': 'fastest',
+        }),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('LocalRideSearchCacheModel', () {
+    test('round-trips through json and restores entities', () {
+      final cache = buildSearchCache();
+
+      final restored = LocalRideSearchCacheModel.fromJson(cache.toJson());
+      final entities = restored.toEntities();
+
+      expect(restored.version, LocalRideSearchCacheModel.currentVersion);
+      expect(restored.savedAt, cache.savedAt);
+      expect(restored.filters.originQuery, cache.filters.originQuery);
+      expect(restored.filters.destinationQuery, cache.filters.destinationQuery);
+      expect(restored.filters.selectedDate, cache.filters.selectedDate);
+      expect(restored.results, hasLength(2));
+      expect(entities.map((ride) => ride.id), <String>['ride-1', 'ride-2']);
+      expect(
+        entities.map((ride) => ride.paymentOption),
+        <Object>[RidePaymentOption.card, RidePaymentOption.bankTransfer],
+      );
+    });
+
+    test('create builds a versioned cache from rides entities', () {
+      final cache = LocalRideSearchCacheModel.create(
+        filters: buildSearchFilters(sort: RideSortOption.earliest),
+        results: <RidesEntity>[
+          buildTestRide(id: 'ride-1'),
+          buildTestRide(id: 'ride-2'),
+        ],
+      );
+
+      expect(cache.version, LocalRideSearchCacheModel.currentVersion);
+      expect(cache.results, hasLength(2));
+      expect(cache.filters.sort, RideSortOption.earliest);
+    });
+
+    test('throws when cache version is unsupported', () {
+      final invalidJson = buildSearchCache().toJson()..['version'] = 999;
+
+      expect(
+        () => LocalRideSearchCacheModel.fromJson(invalidJson),
+        throwsFormatException,
+      );
+    });
+
+    test('throws when a result item is not a map', () {
+      final invalidJson = buildSearchCache().toJson()..['results'] = <Object>[
+          'not-a-map',
+        ];
+
+      expect(
+        () => LocalRideSearchCacheModel.fromJson(invalidJson),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/wheels/test/features/rides/data/models/local_ride_search_cache_model_test.dart
+++ b/wheels/test/features/rides/data/models/local_ride_search_cache_model_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(restored.savedAt, cache.savedAt);
       expect(restored.filters.originQuery, cache.filters.originQuery);
       expect(restored.filters.destinationQuery, cache.filters.destinationQuery);
-      expect(restored.filters.selectedDate, cache.filters.selectedDate);
+      expect(restored.filters.selectedDate, DateTime(2026, 4, 24));
       expect(restored.results, hasLength(2));
       expect(entities.map((ride) => ride.id), <String>['ride-1', 'ride-2']);
       expect(

--- a/wheels/test/support/ride_test_data.dart
+++ b/wheels/test/support/ride_test_data.dart
@@ -1,0 +1,93 @@
+import 'package:wheels/features/rides/data/models/local_ride_details_cache_model.dart';
+import 'package:wheels/features/rides/data/models/local_ride_search_cache_model.dart';
+import 'package:wheels/features/rides/domain/entities/rides_entity.dart';
+import 'package:wheels/features/rides/presentation/models/ride_listing.dart';
+
+RidesEntity buildTestRide({
+  String id = 'ride-1',
+  String status = 'open',
+  RidePaymentOption paymentOption = RidePaymentOption.card,
+  DateTime? departureAt,
+  DateTime? createdAt,
+  DateTime? updatedAt,
+  List<String>? passengerIds,
+}) {
+  final departure = departureAt ?? DateTime.utc(2026, 4, 24, 13, 0);
+  final created = createdAt ?? DateTime.utc(2026, 4, 24, 10, 0);
+  final updated = updatedAt ?? DateTime.utc(2026, 4, 24, 11, 0);
+
+  return RidesEntity(
+    id: id,
+    driverId: 'driver-1',
+    driverName: 'Martin Driver',
+    driverEmail: 'martin@uniandes.edu.co',
+    origin: 'Uniandes',
+    destination: 'Cedritos',
+    departureAt: departure,
+    estimatedDurationMinutes: 35,
+    totalSeats: 4,
+    availableSeats: 2,
+    pricePerSeat: 12000,
+    paymentOption: paymentOption,
+    status: status,
+    notes: 'Please be on time.',
+    passengerIds: passengerIds ?? const <String>['passenger-1', 'passenger-2'],
+    createdAt: created,
+    updatedAt: updated,
+    driverRating: 4.8,
+    reviewCount: 16,
+    onTimeRate: 92,
+    verifiedByUniversity: true,
+  );
+}
+
+LocalRideSearchFiltersModel buildSearchFilters({
+  String originQuery = 'Uniandes',
+  String destinationQuery = 'Cedritos',
+  DateTime? selectedDate,
+  RideSortOption sort = RideSortOption.smartMatch,
+}) {
+  return LocalRideSearchFiltersModel(
+    originQuery: originQuery,
+    destinationQuery: destinationQuery,
+    selectedDate: selectedDate ?? DateTime.utc(2026, 4, 24, 18, 45),
+    sort: sort,
+  );
+}
+
+LocalRideSearchCacheModel buildSearchCache({
+  DateTime? savedAt,
+  LocalRideSearchFiltersModel? filters,
+  List<LocalRideSearchResultModel>? results,
+}) {
+  return LocalRideSearchCacheModel(
+    version: LocalRideSearchCacheModel.currentVersion,
+    savedAt: savedAt ?? DateTime.utc(2026, 4, 24, 12, 0),
+    filters: filters ?? buildSearchFilters(),
+    results:
+        results ??
+        <LocalRideSearchResultModel>[
+          LocalRideSearchResultModel.fromEntity(buildTestRide(id: 'ride-1')),
+          LocalRideSearchResultModel.fromEntity(
+            buildTestRide(
+              id: 'ride-2',
+              paymentOption: RidePaymentOption.bankTransfer,
+              departureAt: DateTime.utc(2026, 4, 24, 15, 30),
+            ),
+          ),
+        ],
+  );
+}
+
+LocalRideDetailsCacheModel buildRideDetailsCache({
+  String rideId = 'ride-1',
+  DateTime? savedAt,
+}) {
+  final ride = buildTestRide(id: rideId);
+  return LocalRideDetailsCacheModel(
+    version: LocalRideDetailsCacheModel.currentVersion,
+    rideId: ride.id,
+    savedAt: savedAt ?? DateTime.utc(2026, 4, 24, 12, 0),
+    ride: LocalRideDetailsModel.fromEntity(ride),
+  );
+}


### PR DESCRIPTION
## PR Description

### Title
Fix ride completion payment persistence and strengthen withdrawal request validation

### Description
This PR fixes two functional issues detected during a bug review of the app.

First, it corrects the ride completion flow in `ActiveRideScreen`, where passenger payment states were not being fully persisted when a ride was finished. Second, it strengthens `WithdrawalRequestScreen` so the withdrawal form only appears when the wallet summary has been loaded successfully and prevents users from submitting an amount greater than their available balance.

### What changed
- Updated `ActiveRideScreen` so finishing a ride persists final payment states for all relevant passengers
- Fixed passenger payment updates to use `application.passengerId` instead of the application document id
- Adjusted the ride completion modal to close cleanly when the user goes back
- Updated the success message after ride completion to reflect the real behavior of the flow
- Updated `WithdrawalRequestScreen` to respect the async wallet loading state
- Added a wallet loading state before showing the withdrawal form
- Added a wallet error state with retry action if the summary cannot be loaded
- Added validation to prevent withdrawal amounts larger than the available balance
- Disabled withdrawal submission if the wallet does not meet the minimum withdrawal conditions

### Why this matters
These fixes address real consistency and usability problems:
- In ride completion, the app was at risk of leaving passenger payment data in an incomplete state
- In withdrawals, users could interact with the form before the wallet was ready and could attempt amounts that should never be accepted

Together, these changes make the app safer and more predictable in two sensitive flows: trip closure and money withdrawal.

### Files affected
- `lib/features/rides/presentation/screens/active_ride_screen.dart`
- `lib/features/wallet/presentation/screens/withdrawal_request_screen.dart`

### Result
The ride completion flow now persists passenger payment outcomes more reliably, and the withdrawal flow now validates against real wallet data before allowing submission.
