### PR TITLE
business question martin implemented

### DIFF
--- a/wheels/lib/features/admin/presentation/admin_dashboard.dart
+++ b/wheels/lib/features/admin/presentation/admin_dashboard.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../theme/app_colors.dart';
 import '../../engagement/presentation/providers/engagement_providers.dart';
+import 'providers/ride_conversion_providers.dart';
 
 class AdminDashboard extends ConsumerStatefulWidget {
   const AdminDashboard({super.key});
@@ -14,10 +15,13 @@ class AdminDashboard extends ConsumerStatefulWidget {
 
 class _AdminDashboardState extends ConsumerState<AdminDashboard> {
   String? _selectedUserId;
+  bool _isRebuildingRideAnalytics = false;
 
   @override
   Widget build(BuildContext context) {
     final usersAsync = ref.watch(adminUsersProvider);
+    final rideConversionSummaryAsync = ref.watch(rideConversionSummaryProvider);
+    final rideConversionRoutesAsync = ref.watch(rideConversionRoutesProvider);
 
     return Scaffold(
       backgroundColor: const Color(0xFFF4F7FB),
@@ -83,6 +87,13 @@ class _AdminDashboardState extends ConsumerState<AdminDashboard> {
                         counts: counts,
                         preferredHour: preferredHour,
                       ),
+                      const SizedBox(height: 20),
+                      _RideConversionSection(
+                        summaryAsync: rideConversionSummaryAsync,
+                        routesAsync: rideConversionRoutesAsync,
+                        isRebuilding: _isRebuildingRideAnalytics,
+                        onRebuild: _rebuildRideConversionAnalytics,
+                      ),
                     ],
                   );
                 },
@@ -107,6 +118,55 @@ class _AdminDashboardState extends ConsumerState<AdminDashboard> {
       24,
       (hour) => (countsMap['$hour'] as num? ?? 0).toInt(),
     );
+  }
+
+  Future<void> _rebuildRideConversionAnalytics() async {
+    if (_isRebuildingRideAnalytics) {
+      return;
+    }
+
+    setState(() {
+      _isRebuildingRideAnalytics = true;
+    });
+
+    try {
+      await ref
+          .read(rideConversionAnalyticsAdminServiceProvider)
+          .rebuildAnalytics();
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Ride conversion analytics were rebuilt from the current rides collection.',
+            ),
+          ),
+        );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(
+              'Could not rebuild ride conversion analytics: $error',
+            ),
+          ),
+        );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isRebuildingRideAnalytics = false;
+        });
+      }
+    }
   }
 }
 
@@ -368,6 +428,276 @@ class _BarChartCard extends StatelessWidget {
                     ),
                 ],
               ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RideConversionSection extends StatelessWidget {
+  const _RideConversionSection({
+    required this.summaryAsync,
+    required this.routesAsync,
+    required this.isRebuilding,
+    required this.onRebuild,
+  });
+
+  final AsyncValue<RideConversionSummary?> summaryAsync;
+  final AsyncValue<List<RideConversionRouteSummary>> routesAsync;
+  final bool isRebuilding;
+  final Future<void> Function() onRebuild;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(28),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Ride conversion efficiency',
+            style: TextStyle(
+              color: AppColors.primary,
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Business question: What percentage of published rides end up being completed?',
+            style: TextStyle(color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 12),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: FilledButton.icon(
+              onPressed: isRebuilding ? null : onRebuild,
+              icon: isRebuilding
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.refresh_rounded),
+              label: Text(
+                isRebuilding
+                    ? 'Rebuilding metrics...'
+                    : 'Rebuild from current rides',
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          summaryAsync.when(
+            data: (summary) {
+              if (summary == null) {
+                return const Text('No ride conversion analytics available yet.');
+              }
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      _AnalyticsMetricCard(
+                        label: 'Published rides',
+                        value: '${summary.totalPublishedRides}',
+                      ),
+                      _AnalyticsMetricCard(
+                        label: 'Completed rides',
+                        value: '${summary.completedRides}',
+                      ),
+                      _AnalyticsMetricCard(
+                        label: 'Completion rate',
+                        value:
+                            '${(summary.completionRate * 100).toStringAsFixed(1)}%',
+                      ),
+                      _AnalyticsMetricCard(
+                        label: 'Cancellation rate',
+                        value:
+                            '${(summary.cancellationRate * 100).toStringAsFixed(1)}%',
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      _CompactStatusChip(
+                        label: 'Open',
+                        value: summary.openRides,
+                      ),
+                      _CompactStatusChip(
+                        label: 'In progress',
+                        value: summary.inProgressRides,
+                      ),
+                      _CompactStatusChip(
+                        label: 'Completed',
+                        value: summary.completedRides,
+                      ),
+                      _CompactStatusChip(
+                        label: 'Cancelled',
+                        value: summary.cancelledRides,
+                      ),
+                    ],
+                  ),
+                ],
+              );
+            },
+            loading: () => const Padding(
+              padding: EdgeInsets.symmetric(vertical: 20),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (error, _) => Text('Could not load ride metrics: $error'),
+          ),
+          const SizedBox(height: 18),
+          const Text(
+            'Top routes by completed rides',
+            style: TextStyle(
+              color: AppColors.primary,
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 10),
+          routesAsync.when(
+            data: (routes) {
+              if (routes.isEmpty) {
+                return const Text('No route summaries available yet.');
+              }
+
+              return Column(
+                children: routes
+                    .map(
+                      (route) => Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: _RouteConversionTile(route: route),
+                      ),
+                    )
+                    .toList(),
+              );
+            },
+            loading: () => const Padding(
+              padding: EdgeInsets.symmetric(vertical: 12),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (error, _) => Text('Could not load route metrics: $error'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AnalyticsMetricCard extends StatelessWidget {
+  const _AnalyticsMetricCard({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 170,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF5F8FC),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 12,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            style: const TextStyle(
+              color: AppColors.primary,
+              fontSize: 22,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CompactStatusChip extends StatelessWidget {
+  const _CompactStatusChip({required this.label, required this.value});
+
+  final String label;
+  final int value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF5F8FC),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Text(
+        '$label: $value',
+        style: const TextStyle(
+          color: AppColors.primary,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteConversionTile extends StatelessWidget {
+  const _RouteConversionTile({required this.route});
+
+  final RideConversionRouteSummary route;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF5F8FC),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            route.routeLabel,
+            style: const TextStyle(
+              color: AppColors.primary,
+              fontWeight: FontWeight.w800,
+              fontSize: 15,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Published: ${route.totalPublishedRides} - Completed: ${route.completedRides} - Cancelled: ${route.cancelledRides}',
+            style: const TextStyle(color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Completion rate: ${(route.completionRate * 100).toStringAsFixed(1)}%',
+            style: const TextStyle(
+              color: AppColors.primary,
+              fontWeight: FontWeight.w700,
             ),
           ),
         ],

--- a/wheels/lib/features/admin/presentation/providers/ride_conversion_providers.dart
+++ b/wheels/lib/features/admin/presentation/providers/ride_conversion_providers.dart
@@ -1,0 +1,283 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final rideConversionAnalyticsAdminServiceProvider =
+    Provider<RideConversionAnalyticsAdminService>((ref) {
+      return RideConversionAnalyticsAdminService(FirebaseFirestore.instance);
+    });
+
+final rideConversionSummaryProvider = StreamProvider<RideConversionSummary?>((
+  ref,
+) {
+  return FirebaseFirestore.instance
+      .collection('analytics')
+      .doc('ride_conversion_summary')
+      .snapshots()
+      .map(RideConversionSummary.fromSnapshot);
+});
+
+final rideConversionRoutesProvider =
+    StreamProvider<List<RideConversionRouteSummary>>((ref) {
+      return FirebaseFirestore.instance
+          .collection('ride_conversion_routes')
+          .orderBy('completedRides', descending: true)
+          .limit(8)
+          .snapshots()
+          .map(
+            (snapshot) => snapshot.docs
+                .map(RideConversionRouteSummary.fromSnapshot)
+                .toList(),
+          );
+    });
+
+class RideConversionSummary {
+  const RideConversionSummary({
+    required this.totalPublishedRides,
+    required this.openRides,
+    required this.inProgressRides,
+    required this.completedRides,
+    required this.cancelledRides,
+    this.updatedAt,
+  });
+
+  final int totalPublishedRides;
+  final int openRides;
+  final int inProgressRides;
+  final int completedRides;
+  final int cancelledRides;
+  final DateTime? updatedAt;
+
+  double get completionRate => totalPublishedRides == 0
+      ? 0
+      : completedRides / totalPublishedRides;
+
+  double get cancellationRate => totalPublishedRides == 0
+      ? 0
+      : cancelledRides / totalPublishedRides;
+
+  factory RideConversionSummary.fromSnapshot(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+  ) {
+    final data = snapshot.data() ?? <String, dynamic>{};
+    return RideConversionSummary(
+      totalPublishedRides: _readInt(data['totalPublishedRides']),
+      openRides: _readInt(data['openRides']),
+      inProgressRides: _readInt(data['inProgressRides']),
+      completedRides: _readInt(data['completedRides']),
+      cancelledRides: _readInt(data['cancelledRides']),
+      updatedAt: _readDateTime(data['updatedAt']),
+    );
+  }
+}
+
+class RideConversionRouteSummary {
+  const RideConversionRouteSummary({
+    required this.routeKey,
+    required this.routeLabel,
+    required this.origin,
+    required this.destination,
+    required this.totalPublishedRides,
+    required this.openRides,
+    required this.inProgressRides,
+    required this.completedRides,
+    required this.cancelledRides,
+    this.updatedAt,
+  });
+
+  final String routeKey;
+  final String routeLabel;
+  final String origin;
+  final String destination;
+  final int totalPublishedRides;
+  final int openRides;
+  final int inProgressRides;
+  final int completedRides;
+  final int cancelledRides;
+  final DateTime? updatedAt;
+
+  double get completionRate => totalPublishedRides == 0
+      ? 0
+      : completedRides / totalPublishedRides;
+
+  factory RideConversionRouteSummary.fromSnapshot(
+    QueryDocumentSnapshot<Map<String, dynamic>> snapshot,
+  ) {
+    final data = snapshot.data();
+    return RideConversionRouteSummary(
+      routeKey: (data['routeKey'] as String?) ?? snapshot.id,
+      routeLabel: (data['routeLabel'] as String?) ?? 'Unknown route',
+      origin: (data['origin'] as String?) ?? '',
+      destination: (data['destination'] as String?) ?? '',
+      totalPublishedRides: _readInt(data['totalPublishedRides']),
+      openRides: _readInt(data['openRides']),
+      inProgressRides: _readInt(data['inProgressRides']),
+      completedRides: _readInt(data['completedRides']),
+      cancelledRides: _readInt(data['cancelledRides']),
+      updatedAt: _readDateTime(data['updatedAt']),
+    );
+  }
+}
+
+int _readInt(Object? rawValue) {
+  if (rawValue is num) {
+    return rawValue.toInt();
+  }
+  return 0;
+}
+
+DateTime? _readDateTime(Object? rawValue) {
+  if (rawValue is Timestamp) {
+    return rawValue.toDate();
+  }
+  return null;
+}
+
+class RideConversionAnalyticsAdminService {
+  const RideConversionAnalyticsAdminService(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  Future<void> rebuildAnalytics() async {
+    final ridesSnapshot = await _firestore.collection('rides').get();
+    final existingRoutesSnapshot = await _firestore
+        .collection('ride_conversion_routes')
+        .get();
+
+    var totalPublishedRides = 0;
+    var openRides = 0;
+    var inProgressRides = 0;
+    var completedRides = 0;
+    var cancelledRides = 0;
+    final routeSummaries = <String, Map<String, dynamic>>{};
+
+    for (final rideDoc in ridesSnapshot.docs) {
+      final data = rideDoc.data();
+      final origin = (data['origin'] as String?)?.trim() ?? '';
+      final destination = (data['destination'] as String?)?.trim() ?? '';
+      final status = ((data['status'] as String?) ?? 'open').trim().toLowerCase();
+      final routeKey = _routeKey(origin, destination);
+      final routeLabel = '$origin -> $destination';
+
+      totalPublishedRides += 1;
+      switch (status) {
+        case 'completed':
+          completedRides += 1;
+          break;
+        case 'cancelled':
+          cancelledRides += 1;
+          break;
+        case 'in_progress':
+          inProgressRides += 1;
+          break;
+        case 'open':
+        default:
+          openRides += 1;
+          break;
+      }
+
+      final routeSummary = routeSummaries.putIfAbsent(routeKey, () {
+        return <String, dynamic>{
+          'routeKey': routeKey,
+          'routeLabel': routeLabel,
+          'origin': origin,
+          'destination': destination,
+          'totalPublishedRides': 0,
+          'openRides': 0,
+          'inProgressRides': 0,
+          'completedRides': 0,
+          'cancelledRides': 0,
+        };
+      });
+
+      routeSummary['totalPublishedRides'] =
+          (routeSummary['totalPublishedRides'] as int) + 1;
+      switch (status) {
+        case 'completed':
+          routeSummary['completedRides'] =
+              (routeSummary['completedRides'] as int) + 1;
+          break;
+        case 'cancelled':
+          routeSummary['cancelledRides'] =
+              (routeSummary['cancelledRides'] as int) + 1;
+          break;
+        case 'in_progress':
+          routeSummary['inProgressRides'] =
+              (routeSummary['inProgressRides'] as int) + 1;
+          break;
+        case 'open':
+        default:
+          routeSummary['openRides'] = (routeSummary['openRides'] as int) + 1;
+          break;
+      }
+    }
+
+    final operations = <void Function(WriteBatch)>[
+      (batch) => batch.set(
+        _firestore.collection('analytics').doc('ride_conversion_summary'),
+        <String, dynamic>{
+          'question':
+              'What percentage of published rides end up being completed?',
+          'totalPublishedRides': totalPublishedRides,
+          'openRides': openRides,
+          'inProgressRides': inProgressRides,
+          'completedRides': completedRides,
+          'cancelledRides': cancelledRides,
+          'recomputedAt': FieldValue.serverTimestamp(),
+          'updatedAt': FieldValue.serverTimestamp(),
+        },
+      ),
+    ];
+
+    for (final doc in existingRoutesSnapshot.docs) {
+      if (!routeSummaries.containsKey(doc.id)) {
+        operations.add((batch) => batch.delete(doc.reference));
+      }
+    }
+
+    for (final entry in routeSummaries.entries) {
+      operations.add(
+        (batch) => batch.set(
+          _firestore.collection('ride_conversion_routes').doc(entry.key),
+          <String, dynamic>{
+            ...entry.value,
+            'updatedAt': FieldValue.serverTimestamp(),
+          },
+        ),
+      );
+    }
+
+    await _commitBatchOperations(operations);
+  }
+
+  Future<void> _commitBatchOperations(
+    List<void Function(WriteBatch)> operations,
+  ) async {
+    if (operations.isEmpty) {
+      return;
+    }
+
+    const chunkSize = 400;
+    for (var start = 0; start < operations.length; start += chunkSize) {
+      final batch = _firestore.batch();
+      final end = (start + chunkSize > operations.length)
+          ? operations.length
+          : start + chunkSize;
+      for (final operation in operations.sublist(start, end)) {
+        operation(batch);
+      }
+      await batch.commit();
+    }
+  }
+}
+
+String _routeKey(String origin, String destination) {
+  final normalizedOrigin = origin.toLowerCase().replaceAll(
+    RegExp(r'[^a-z0-9]+'),
+    '_',
+  );
+  final normalizedDestination = destination.toLowerCase().replaceAll(
+    RegExp(r'[^a-z0-9]+'),
+    '_',
+  );
+  return '${normalizedOrigin}_to_$normalizedDestination';
+}

--- a/wheels/lib/features/rides/data/datasources/rides_remote_datasource.dart
+++ b/wheels/lib/features/rides/data/datasources/rides_remote_datasource.dart
@@ -15,6 +15,12 @@ class RidesRemoteDataSource {
   CollectionReference<Map<String, dynamic>> get _paymentsCollection =>
       _firestore.collection('payments');
 
+  CollectionReference<Map<String, dynamic>> get _analyticsCollection =>
+      _firestore.collection('analytics');
+
+  CollectionReference<Map<String, dynamic>> get _rideConversionRoutesCollection =>
+      _firestore.collection('ride_conversion_routes');
+
   CollectionReference<Map<String, dynamic>> _applicationsCollection(
     String rideId,
   ) => _ridesCollection.doc(rideId).collection('applications');
@@ -24,6 +30,9 @@ class RidesRemoteDataSource {
     String passengerId,
   ) =>
       _paymentsCollection.doc(rideId).collection('passengers').doc(passengerId);
+
+  DocumentReference<Map<String, dynamic>> get _rideConversionSummaryDocument =>
+      _analyticsCollection.doc('ride_conversion_summary');
 
   Stream<List<RidesEntity>> watchAvailableRides() {
     return _ridesCollection.snapshots().map((snapshot) {
@@ -120,6 +129,8 @@ class RidesRemoteDataSource {
   }) async {
     final document = _ridesCollection.doc();
     final now = DateTime.now();
+    final routeKey = _routeKey(origin, destination);
+    final routeLabel = _routeLabel(origin, destination);
     final ride = RidesModel(
       id: document.id,
       driverId: driverId,
@@ -140,7 +151,30 @@ class RidesRemoteDataSource {
       updatedAt: now,
     );
 
-    await document.set(ride.toFirestore());
+    final batch = _firestore.batch();
+    batch.set(document, ride.toFirestore());
+    batch.set(
+      _rideConversionSummaryDocument,
+      _rideConversionSummaryDelta(
+        statusDelta: const <String, int>{'open': 1},
+        totalPublishedDelta: 1,
+        timestampField: 'lastRideCreatedAt',
+      ),
+      SetOptions(merge: true),
+    );
+    batch.set(
+      _rideConversionRoutesCollection.doc(routeKey),
+      _rideConversionRouteDelta(
+        routeKey: routeKey,
+        routeLabel: routeLabel,
+        origin: origin,
+        destination: destination,
+        statusDelta: const <String, int>{'open': 1},
+        totalPublishedDelta: 1,
+      ),
+      SetOptions(merge: true),
+    );
+    await batch.commit();
     return ride;
   }
 
@@ -180,6 +214,7 @@ class RidesRemoteDataSource {
 
       transaction.update(rideRef, <String, dynamic>{
         'availableSeats': ride.availableSeats - 1,
+        'bookedSeats': ride.bookedSeats + 1,
         'passengerIds': FieldValue.arrayUnion(<String>[passengerId]),
         'updatedAt': FieldValue.serverTimestamp(),
       });
@@ -218,10 +253,47 @@ class RidesRemoteDataSource {
   Future<void> updateRideStatus({
     required String rideId,
     required String status,
-  }) {
-    return _ridesCollection.doc(rideId).update(<String, dynamic>{
-      'status': status,
-      'updatedAt': FieldValue.serverTimestamp(),
+  }) async {
+    final rideRef = _ridesCollection.doc(rideId);
+    await _firestore.runTransaction((transaction) async {
+      final rideSnapshot = await transaction.get(rideRef);
+      if (!rideSnapshot.exists) {
+        throw const RideFailure('This ride is no longer available.');
+      }
+
+      final ride = RidesModel.fromFirestore(rideSnapshot);
+      final previousStatus = ride.status.trim().toLowerCase();
+      final nextStatus = status.trim().toLowerCase();
+      if (previousStatus == nextStatus) {
+        return;
+      }
+
+      transaction.update(rideRef, <String, dynamic>{
+        'status': status,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+      transaction.set(
+        _rideConversionSummaryDocument,
+        _rideConversionSummaryDelta(
+          statusDelta: <String, int>{previousStatus: -1, nextStatus: 1},
+          totalPublishedDelta: 0,
+          timestampField: 'lastStatusChangedAt',
+        ),
+        SetOptions(merge: true),
+      );
+      final routeKey = _routeKey(ride.origin, ride.destination);
+      transaction.set(
+        _rideConversionRoutesCollection.doc(routeKey),
+        _rideConversionRouteDelta(
+          routeKey: routeKey,
+          routeLabel: _routeLabel(ride.origin, ride.destination),
+          origin: ride.origin,
+          destination: ride.destination,
+          statusDelta: <String, int>{previousStatus: -1, nextStatus: 1},
+          totalPublishedDelta: 0,
+        ),
+        SetOptions(merge: true),
+      );
     });
   }
 
@@ -366,5 +438,77 @@ class RidesRemoteDataSource {
           : 'card_payment_pending_confirmation';
     }
     return 'awaiting_manual_transfer_confirmation';
+  }
+
+  Map<String, dynamic> _rideConversionSummaryDelta({
+    required Map<String, int> statusDelta,
+    required int totalPublishedDelta,
+    required String timestampField,
+  }) {
+    return <String, dynamic>{
+      'question':
+          'What percentage of published rides end up being completed?',
+      'totalPublishedRides': FieldValue.increment(totalPublishedDelta),
+      'openRides': FieldValue.increment(_statusDelta(statusDelta, 'open')),
+      'inProgressRides': FieldValue.increment(
+        _statusDelta(statusDelta, 'in_progress'),
+      ),
+      'completedRides': FieldValue.increment(
+        _statusDelta(statusDelta, 'completed'),
+      ),
+      'cancelledRides': FieldValue.increment(
+        _statusDelta(statusDelta, 'cancelled'),
+      ),
+      timestampField: FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  Map<String, dynamic> _rideConversionRouteDelta({
+    required String routeKey,
+    required String routeLabel,
+    required String origin,
+    required String destination,
+    required Map<String, int> statusDelta,
+    required int totalPublishedDelta,
+  }) {
+    return <String, dynamic>{
+      'routeKey': routeKey,
+      'routeLabel': routeLabel,
+      'origin': origin,
+      'destination': destination,
+      'totalPublishedRides': FieldValue.increment(totalPublishedDelta),
+      'openRides': FieldValue.increment(_statusDelta(statusDelta, 'open')),
+      'inProgressRides': FieldValue.increment(
+        _statusDelta(statusDelta, 'in_progress'),
+      ),
+      'completedRides': FieldValue.increment(
+        _statusDelta(statusDelta, 'completed'),
+      ),
+      'cancelledRides': FieldValue.increment(
+        _statusDelta(statusDelta, 'cancelled'),
+      ),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  int _statusDelta(Map<String, int> statusDelta, String key) {
+    return statusDelta[key] ?? 0;
+  }
+
+  String _routeKey(String origin, String destination) {
+    final normalizedOrigin = origin.trim().toLowerCase().replaceAll(
+      RegExp(r'[^a-z0-9]+'),
+      '_',
+    );
+    final normalizedDestination = destination.trim().toLowerCase().replaceAll(
+      RegExp(r'[^a-z0-9]+'),
+      '_',
+    );
+    return '${normalizedOrigin}_to_$normalizedDestination';
+  }
+
+  String _routeLabel(String origin, String destination) {
+    return '${origin.trim()} -> ${destination.trim()}';
   }
 }

--- a/wheels/lib/features/rides/data/models/rides_model.dart
+++ b/wheels/lib/features/rides/data/models/rides_model.dart
@@ -75,18 +75,25 @@ class RidesModel extends RidesEntity {
   }
 
   Map<String, dynamic> toFirestore() {
+    final routeLabel = '${origin.trim()} -> ${destination.trim()}';
+    final routeKey =
+        '${origin.trim().toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_')}_to_'
+        '${destination.trim().toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_')}';
     return <String, dynamic>{
       'driverId': driverId,
       'driverName': driverName,
       'driverEmail': driverEmail,
       'origin': origin,
       'destination': destination,
+      'routeLabel': routeLabel,
+      'routeKey': routeKey,
       'originSearch': origin.toLowerCase(),
       'destinationSearch': destination.toLowerCase(),
       'departureAt': Timestamp.fromDate(departureAt),
       'estimatedDurationMinutes': estimatedDurationMinutes,
       'totalSeats': totalSeats,
       'availableSeats': availableSeats,
+      'bookedSeats': bookedSeats,
       'pricePerSeat': pricePerSeat,
       'paymentOption': paymentOption.storageValue,
       'status': status,


### PR DESCRIPTION
## PR Description

### Title
Implement ride conversion business question and admin analytics support

### Description
This PR adds a new business question focused on the operational efficiency of the ride lifecycle:

**What percentage of published rides end up being completed?**

To support this, the app now computes and persists ride conversion aggregates, exposes them in the admin analytics UI, and prepares the data so it can be consumed by downstream analytics tools such as BigQuery and Looker Studio.

### What changed
- Added ride conversion analytics aggregation for the rides domain
- Persisted global conversion metrics in:
  - `analytics/ride_conversion_summary`
- Persisted route-level conversion metrics in:
  - `ride_conversion_routes/<routeKey>`
- Extended ride persistence so ride documents include derived analytics fields such as:
  - `routeKey`
  - `routeLabel`
  - `bookedSeats`
- Updated ride creation and ride status transitions so conversion counters stay in sync
- Added admin-side providers and service logic to:
  - read conversion analytics
  - rebuild analytics from the current rides collection
- Added a new `Ride conversion efficiency` section to the admin dashboard
- Included an admin action to recompute analytics from existing ride data

### Why this matters
This business question helps evaluate whether one of the core product features is working effectively: publishing rides and successfully converting them into completed trips.

It provides visibility into:
- total published rides
- completed rides
- cancellation volume
- ride completion rate
- route-level conversion performance

This makes it easier to reason about operational efficiency and identify where the ride funnel loses performance.

### Files affected
- `lib/features/admin/presentation/admin_dashboard.dart`
- `lib/features/admin/presentation/providers/ride_conversion_providers.dart`
- `lib/features/rides/data/datasources/rides_remote_datasource.dart`
- `lib/features/rides/data/models/rides_model.dart`

### Result
The app now supports a new Type 3 (Features) business question by computing ride conversion analytics directly from product behavior and exposing the results through admin analytics and analytics-ready persistence.
