### PR TITLE
Implemented LRU

### DIFF
--- a/wheels/lib/features/wallet/data/datasources/wallet_summary_local_datasource.dart
+++ b/wheels/lib/features/wallet/data/datasources/wallet_summary_local_datasource.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
+import '../../../../shared/cache/memory_lru_cache.dart';
 import '../../../../shared/storage/app_hive.dart';
 import '../models/local_wallet_summary_cache_model.dart';
 
@@ -22,9 +23,18 @@ String _encodeWalletSummaryCache(LocalWalletSummaryCacheModel cache) {
 }
 
 class WalletSummaryLocalDataSource {
-  const WalletSummaryLocalDataSource();
+  WalletSummaryLocalDataSource({
+    required MemoryLruCache<String, LocalWalletSummaryCacheModel> memoryCache,
+  }) : _memoryCache = memoryCache;
+
+  final MemoryLruCache<String, LocalWalletSummaryCacheModel> _memoryCache;
 
   Future<LocalWalletSummaryCacheModel?> loadLatestWalletSummary() async {
+    final memoryHit = _memoryCache.get(AppHiveKeys.latestWalletSummary);
+    if (memoryHit != null) {
+      return memoryHit;
+    }
+
     final box = Hive.box<String>(AppHiveBoxes.walletSummaryCache);
     final rawCache = box.get(AppHiveKeys.latestWalletSummary);
     if (rawCache == null || rawCache.trim().isEmpty) {
@@ -32,7 +42,9 @@ class WalletSummaryLocalDataSource {
     }
 
     try {
-      return await compute(_decodeWalletSummaryCache, rawCache);
+      final cache = await compute(_decodeWalletSummaryCache, rawCache);
+      _memoryCache.put(AppHiveKeys.latestWalletSummary, cache);
+      return cache;
     } catch (_) {
       await clearLatestWalletSummary();
       return null;
@@ -45,10 +57,12 @@ class WalletSummaryLocalDataSource {
     final encoded = await compute(_encodeWalletSummaryCache, cache);
     final box = Hive.box<String>(AppHiveBoxes.walletSummaryCache);
     await box.put(AppHiveKeys.latestWalletSummary, encoded);
+    _memoryCache.put(AppHiveKeys.latestWalletSummary, cache);
   }
 
   Future<void> clearLatestWalletSummary() async {
     final box = Hive.box<String>(AppHiveBoxes.walletSummaryCache);
     await box.delete(AppHiveKeys.latestWalletSummary);
+    _memoryCache.remove(AppHiveKeys.latestWalletSummary);
   }
 }

--- a/wheels/lib/features/wallet/presentation/providers/wallet_providers.dart
+++ b/wheels/lib/features/wallet/presentation/providers/wallet_providers.dart
@@ -1,10 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../shared/cache/memory_lru_cache.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../../data/datasources/withdrawal_request_draft_local_datasource.dart';
 import '../../data/datasources/wallet_remote_datasource.dart';
 import '../../data/datasources/wallet_summary_local_datasource.dart';
 import '../../data/repositories/wallet_repository_impl.dart';
+import '../../data/models/local_wallet_summary_cache_model.dart';
 import '../../domain/entities/withdrawal_request_input.dart';
 import '../../domain/entities/wallet_summary.dart';
 import '../../domain/repositories/wallet_repository.dart';
@@ -18,9 +20,19 @@ final withdrawalRequestDraftLocalDataSourceProvider =
       return const WithdrawalRequestDraftLocalDataSource();
     });
 
+final walletSummaryMemoryCacheProvider =
+    Provider<MemoryLruCache<String, LocalWalletSummaryCacheModel>>((ref) {
+      // The wallet screen only needs the latest snapshot, so a tiny LRU is enough.
+      return MemoryLruCache<String, LocalWalletSummaryCacheModel>(
+        maxEntries: 1,
+      );
+    });
+
 final walletSummaryLocalDataSourceProvider =
     Provider<WalletSummaryLocalDataSource>((ref) {
-      return const WalletSummaryLocalDataSource();
+      return WalletSummaryLocalDataSource(
+        memoryCache: ref.watch(walletSummaryMemoryCacheProvider),
+      );
     });
 
 final walletRepositoryProvider = Provider<WalletRepository>((ref) {

--- a/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
+++ b/wheels/lib/features/wallet/presentation/screens/withdrawal_request_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../../shared/providers/connectivity_provider.dart';
 import '../../../../shared/ui/app_scaffold.dart';
@@ -37,6 +38,7 @@ class _WithdrawalRequestScreenState
 
   Timer? _draftSaveDebounce;
   String _accountType = 'savings';
+  String _preferredAccountType = 'savings';
   bool _isDraftLoaded = false;
   bool _draftRestored = false;
   bool _isApplyingLocalState = false;
@@ -48,6 +50,13 @@ class _WithdrawalRequestScreenState
     return user == null
         ? 'anonymous_withdrawal_request'
         : 'withdrawal_request_${user.uid}';
+  }
+
+  String get _preferredAccountTypeKey {
+    final user = ref.read(authUserProvider);
+    return user == null
+        ? 'preferred_withdrawal_account_type_anonymous'
+        : 'preferred_withdrawal_account_type_${user.uid}';
   }
 
   @override
@@ -100,6 +109,7 @@ class _WithdrawalRequestScreenState
   }
 
   Future<void> _restoreDraftIfAvailable() async {
+    final preferredAccountType = await _loadPreferredAccountType();
     final draft = await ref
         .read(withdrawalRequestDraftLocalDataSourceProvider)
         .loadDraft(cacheId: _draftCacheId);
@@ -107,6 +117,9 @@ class _WithdrawalRequestScreenState
     if (!mounted) {
       return;
     }
+
+    _preferredAccountType = preferredAccountType;
+    _accountType = preferredAccountType;
 
     if (draft != null && draft.hasMeaningfulData) {
       _isApplyingLocalState = true;
@@ -123,6 +136,20 @@ class _WithdrawalRequestScreenState
       _draftRestored = draft != null && draft.hasMeaningfulData;
       _draftSavedAt = draft?.savedAt;
     });
+  }
+
+  Future<String> _loadPreferredAccountType() async {
+    final prefs = await SharedPreferences.getInstance();
+    final preferred = prefs.getString(_preferredAccountTypeKey);
+    if (preferred == 'checking') {
+      return 'checking';
+    }
+    return 'savings';
+  }
+
+  Future<void> _savePreferredAccountType(String value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_preferredAccountTypeKey, value);
   }
 
   Future<void> _persistDraft({bool showFeedback = false}) async {
@@ -183,7 +210,7 @@ class _WithdrawalRequestScreenState
     _bankNameController.clear();
     _accountNumberController.clear();
     _accountHolderNameController.clear();
-    _accountType = 'savings';
+    _accountType = _preferredAccountType;
     _isApplyingLocalState = false;
     _formKey.currentState?.reset();
 
@@ -371,9 +398,11 @@ class _WithdrawalRequestScreenState
                               ? null
                               : (value) {
                                   if (value != null) {
+                                    _preferredAccountType = value;
                                     setState(() {
                                       _accountType = value;
                                     });
+                                    unawaited(_savePreferredAccountType(value));
                                     _scheduleDraftSave();
                                   }
                                 },


### PR DESCRIPTION
## PR Description

### Title
Strengthen wallet local storage and caching strategies

### Description
This PR improves the wallet-related resilience layer by extending the local storage strategy and introducing an explicit in-memory LRU cache for wallet snapshots.

The goal is to make the wallet flow stronger from both a product and infrastructure perspective: preserving user state more intentionally, reducing repeated reads of locally persisted data, and making the implementation easier to defend in terms of caching and local storage strategies.

### What changed
- Added an in-memory LRU cache for wallet summary snapshots
- Integrated the LRU cache into the wallet local data source
- Kept Hive as the persistent second-level cache for wallet summaries
- Updated the wallet local data source so it now follows a two-level cache strategy:
  - memory LRU cache first
  - Hive persistent cache second
- Added `SharedPreferences` persistence for the preferred withdrawal account type
- Restored the preferred account type when opening the withdrawal request form
- Updated the withdrawal form reset behavior so it falls back to the saved preference instead of always defaulting to `savings`

### Why this matters
This PR improves two rubric-relevant areas at once:

- **Caching**
  - the wallet now uses an explicit LRU memory cache layered on top of persistent local storage
- **Local storage**
  - the withdrawal flow now distinguishes between:
    - transient draft data stored in Hive
    - stable user preference data stored in `SharedPreferences`

This results in a cleaner architecture and a stronger technical justification for resilience-related design decisions.

### Files affected
- `lib/features/wallet/data/datasources/wallet_summary_local_datasource.dart`
- `lib/features/wallet/presentation/providers/wallet_providers.dart`
- `lib/features/wallet/presentation/screens/withdrawal_request_screen.dart`

### Result
The wallet flow now has:
- a two-level cache strategy for wallet summary data
- a richer local storage strategy for withdrawal preferences
- clearer separation between cached snapshots, temporary drafts, and durable user preferences
