### PR TITLE
Feature/saved destinations trip planner #146

### DIFF
--- a/wheels/lib/features/rides/presentation/screens/create_ride_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/create_ride_screen.dart
@@ -17,6 +17,9 @@ import '../../../../theme/app_radius.dart';
 import '../../../../theme/app_shadows.dart';
 import '../../../../theme/app_spacing.dart';
 import '../../../../theme/app_theme_palette.dart';
+import '../../../saved_destinations/domain/entities/saved_destination.dart';
+import '../../../saved_destinations/presentation/providers/saved_destinations_providers.dart';
+import '../../../saved_destinations/presentation/widgets/saved_destinations_chip.dart';
 import '../../data/models/local_create_ride_draft_model.dart';
 import '../../domain/entities/rides_entity.dart';
 import '../providers/rides_providers.dart';
@@ -55,6 +58,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
   String? _currentLocationSuggestion;
   String? _draftSyncReason;
   DateTime? _draftSavedAt;
+  bool _hasAppliedLastQuickPick = false;
 
   static const List<String> _campusLocations = <String>[
     'Campus Uniandes - Main Gate',
@@ -78,6 +82,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
     Future.microtask(() async {
       await _restoreDraftIfAvailable();
       await _prefillOriginWithCurrentLocation();
+      await _applyLastQuickPickIfRelevant();
     });
   }
 
@@ -117,6 +122,29 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
     } catch (_) {
       // Keep the field empty if the app cannot resolve the location on load.
     }
+  }
+
+  Future<void> _applyLastQuickPickIfRelevant() async {
+    if (_hasAppliedLastQuickPick || _destination.trim().isNotEmpty) {
+      return;
+    }
+
+    final userId = ref.read(authUserProvider)?.uid;
+    if (userId == null) {
+      return;
+    }
+
+    final quickPick = await ref
+        .read(savedDestinationsRepositoryProvider)
+        .loadLastQuickPick(userId);
+    if (!mounted || quickPick == null) {
+      return;
+    }
+
+    setState(() {
+      _destination = quickPick.address;
+      _hasAppliedLastQuickPick = true;
+    });
   }
 
   String get _draftCacheId {
@@ -629,13 +657,36 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
     }
   }
 
+  void _applySavedDestination(SavedDestination destination) {
+    setState(() {
+      _destination = destination.address;
+    });
+    _scheduleDraftAutosave();
+
+    final userId = ref.read(authUserProvider)?.uid;
+    final localId = destination.localId;
+    if (userId != null && localId != null) {
+      unawaited(
+        ref.read(savedDestinationsRepositoryProvider).saveLastQuickPick(
+              userId: userId,
+              localId: localId,
+            ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final role = ref.watch(currentUserRoleProvider);
+    ref.watch(savedDestinationsFeatureInitProvider);
     final createRideState = ref.watch(createRideControllerProvider);
     final connectivityAsync = ref.watch(connectivityStatusProvider);
     final isOnline = connectivityAsync.valueOrNull ?? true;
     final palette = context.palette;
+    final savedDestinations =
+        ref.watch(savedDestinationsStreamProvider).valueOrNull ??
+        const <SavedDestination>[];
+    final quickDestinations = savedDestinations.take(4).toList(growable: false);
 
     ref.listen<AsyncValue<String?>>(createRideControllerProvider, (
       previous,
@@ -817,6 +868,54 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
                       validatorText: 'Destination is required.',
                       suggestions: _locationSuggestionsFor,
                     ),
+                    const SizedBox(height: AppSpacing.s),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            quickDestinations.isEmpty
+                                ? 'Saved destinations'
+                                : 'Quick destinations',
+                            style: TextStyle(
+                              color: palette.textPrimary,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        TextButton(
+                          onPressed: () =>
+                              context.push(AppRoutes.savedDestinations),
+                          child: Text(
+                            quickDestinations.isEmpty ? 'Open' : 'Manage',
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (quickDestinations.isNotEmpty) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Wrap(
+                          spacing: AppSpacing.s,
+                          runSpacing: AppSpacing.s,
+                          children: [
+                            for (final destination in quickDestinations)
+                              SavedDestinationsChip(
+                                destination: destination,
+                                onTap: () => _applySavedDestination(destination),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ] else ...[
+                      Text(
+                        'Save favorite places to prefill future ride publications.',
+                        style: TextStyle(
+                          color: palette.textSecondary,
+                          height: 1.35,
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               ),

--- a/wheels/lib/features/rides/presentation/screens/create_ride_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/create_ride_screen.dart
@@ -25,7 +25,14 @@ import '../../domain/entities/rides_entity.dart';
 import '../providers/rides_providers.dart';
 
 class CreateRideScreen extends ConsumerStatefulWidget {
-  const CreateRideScreen({super.key});
+  const CreateRideScreen({
+    this.initialSavedDestinationId,
+    this.forceSavedDestination = false,
+    super.key,
+  });
+
+  final int? initialSavedDestinationId;
+  final bool forceSavedDestination;
 
   @override
   ConsumerState<CreateRideScreen> createState() => _CreateRideScreenState();
@@ -59,6 +66,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
   String? _draftSyncReason;
   DateTime? _draftSavedAt;
   bool _hasAppliedLastQuickPick = false;
+  bool _hasAppliedInitialSavedDestination = false;
 
   static const List<String> _campusLocations = <String>[
     'Campus Uniandes - Main Gate',
@@ -81,6 +89,7 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
     _priceController.addListener(_onDraftFieldChanged);
     Future.microtask(() async {
       await _restoreDraftIfAvailable();
+      await _applyInitialSavedDestinationFromRouteIfRelevant();
       await _prefillOriginWithCurrentLocation();
       await _applyLastQuickPickIfRelevant();
     });
@@ -144,6 +153,34 @@ class _CreateRideScreenState extends ConsumerState<CreateRideScreen> {
     setState(() {
       _destination = quickPick.address;
       _hasAppliedLastQuickPick = true;
+    });
+  }
+
+  Future<void> _applyInitialSavedDestinationFromRouteIfRelevant() async {
+    if (_hasAppliedInitialSavedDestination) {
+      return;
+    }
+
+    if (!widget.forceSavedDestination && _destination.trim().isNotEmpty) {
+      return;
+    }
+
+    final localId = widget.initialSavedDestinationId;
+    final userId = ref.read(authUserProvider)?.uid;
+    if (localId == null || userId == null) {
+      return;
+    }
+
+    final destination = await ref
+        .read(savedDestinationsRepositoryProvider)
+        .loadDestinationById(userId, localId);
+    if (!mounted || destination == null) {
+      return;
+    }
+
+    setState(() {
+      _destination = destination.address;
+      _hasAppliedInitialSavedDestination = true;
     });
   }
 

--- a/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
@@ -25,7 +25,14 @@ import '../models/ride_listing.dart';
 import '../providers/rides_providers.dart';
 
 class RidesSearchScreen extends ConsumerStatefulWidget {
-  const RidesSearchScreen({super.key});
+  const RidesSearchScreen({
+    this.initialSavedDestinationId,
+    this.forceSavedDestination = false,
+    super.key,
+  });
+
+  final int? initialSavedDestinationId;
+  final bool forceSavedDestination;
 
   @override
   ConsumerState<RidesSearchScreen> createState() => _RidesSearchScreenState();
@@ -63,6 +70,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   bool _isShowingOfflineFallback = false;
   bool _isRetryingSearch = false;
   bool _hasAppliedLastQuickPick = false;
+  bool _hasAppliedInitialSavedDestination = false;
 
   @override
   void initState() {
@@ -109,10 +117,38 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   Future<void> _initializeSearchState() async {
     await _restoreLatestSearch();
     await _syncOfflineFallbackWithConnectivity();
+    await _applyInitialSavedDestinationFromRouteIfRelevant();
     if (_cachedSearchCache == null) {
       await _prefillOriginWithCurrentLocation();
       await _applyLastQuickPickIfRelevant();
     }
+  }
+
+  Future<void> _applyInitialSavedDestinationFromRouteIfRelevant() async {
+    if (_hasAppliedInitialSavedDestination) {
+      return;
+    }
+
+    final localId = widget.initialSavedDestinationId;
+    final userId = ref.read(authUserProvider)?.uid;
+    if (localId == null || userId == null) {
+      return;
+    }
+
+    final destination = await ref
+        .read(savedDestinationsRepositoryProvider)
+        .loadDestinationById(userId, localId);
+    if (!mounted || destination == null) {
+      return;
+    }
+
+    setState(() {
+      _destinationController.text = destination.address;
+      _appliedDestinationQuery = widget.forceSavedDestination
+          ? destination.address.trim().toLowerCase()
+          : _appliedDestinationQuery;
+      _hasAppliedInitialSavedDestination = true;
+    });
   }
 
   Future<void> _applyLastQuickPickIfRelevant() async {

--- a/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
+++ b/wheels/lib/features/rides/presentation/screens/rides_search_screen.dart
@@ -15,6 +15,9 @@ import '../../../../theme/app_radius.dart';
 import '../../../../theme/app_shadows.dart';
 import '../../../../theme/app_spacing.dart';
 import '../../../../theme/app_theme_palette.dart';
+import '../../../saved_destinations/domain/entities/saved_destination.dart';
+import '../../../saved_destinations/presentation/providers/saved_destinations_providers.dart';
+import '../../../saved_destinations/presentation/widgets/saved_destinations_chip.dart';
 import '../../data/datasources/rides_search_local_datasource.dart';
 import '../../data/models/local_ride_search_cache_model.dart';
 import '../../domain/entities/rides_entity.dart';
@@ -59,6 +62,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
   String? _lastSavedCacheSignature;
   bool _isShowingOfflineFallback = false;
   bool _isRetryingSearch = false;
+  bool _hasAppliedLastQuickPick = false;
 
   @override
   void initState() {
@@ -107,7 +111,36 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     await _syncOfflineFallbackWithConnectivity();
     if (_cachedSearchCache == null) {
       await _prefillOriginWithCurrentLocation();
+      await _applyLastQuickPickIfRelevant();
     }
+  }
+
+  Future<void> _applyLastQuickPickIfRelevant() async {
+    if (_hasAppliedLastQuickPick || _cachedSearchCache != null) {
+      return;
+    }
+
+    final userId = ref.read(authUserProvider)?.uid;
+    if (userId == null) {
+      return;
+    }
+
+    final quickPick = await ref
+        .read(savedDestinationsRepositoryProvider)
+        .loadLastQuickPick(userId);
+    if (!mounted || quickPick == null) {
+      return;
+    }
+
+    if (_destinationController.text.trim().isNotEmpty) {
+      _hasAppliedLastQuickPick = true;
+      return;
+    }
+
+    setState(() {
+      _destinationController.text = quickPick.address;
+      _hasAppliedLastQuickPick = true;
+    });
   }
 
   Future<void> _syncOfflineFallbackWithConnectivity() async {
@@ -589,6 +622,23 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     ].join('::');
   }
 
+  void _applySavedDestination(SavedDestination destination) {
+    setState(() {
+      _destinationController.text = destination.address;
+    });
+
+    final userId = ref.read(authUserProvider)?.uid;
+    final localId = destination.localId;
+    if (userId != null && localId != null) {
+      unawaited(
+        ref.read(savedDestinationsRepositoryProvider).saveLastQuickPick(
+              userId: userId,
+              localId: localId,
+            ),
+      );
+    }
+  }
+
   Widget _buildResultsSection(
     List<RidesEntity> results, {
     bool isCached = false,
@@ -758,6 +808,7 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
     final palette = context.palette;
     final role = ref.watch(currentUserRoleProvider);
     final ridesAsync = ref.watch(availableRidesProvider);
+    ref.watch(savedDestinationsFeatureInitProvider);
     final connectivityAsync = ref.watch(connectivityStatusProvider);
     final isOnline = connectivityAsync.valueOrNull ?? true;
     final cachedResults = _cachedSearchCache?.toEntities();
@@ -842,6 +893,10 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
 
   Widget _searchCard() {
     final palette = context.palette;
+    final savedDestinations =
+        ref.watch(savedDestinationsStreamProvider).valueOrNull ??
+        const <SavedDestination>[];
+    final quickDestinations = savedDestinations.take(4).toList(growable: false);
 
     return Container(
       padding: const EdgeInsets.all(AppSpacing.m),
@@ -897,6 +952,50 @@ class _RidesSearchScreenState extends ConsumerState<RidesSearchScreen> {
             icon: Icons.place_outlined,
             iconColor: palette.accent,
           ),
+          const SizedBox(height: AppSpacing.s),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  quickDestinations.isEmpty
+                      ? 'Saved destinations'
+                      : 'Quick destinations',
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              TextButton(
+                onPressed: () => context.push(AppRoutes.savedDestinations),
+                child: Text(
+                  quickDestinations.isEmpty ? 'Open' : 'Manage',
+                ),
+              ),
+            ],
+          ),
+          if (quickDestinations.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.s),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Wrap(
+                spacing: AppSpacing.s,
+                runSpacing: AppSpacing.s,
+                children: [
+                  for (final destination in quickDestinations)
+                    SavedDestinationsChip(
+                      destination: destination,
+                      onTap: () => _applySavedDestination(destination),
+                    ),
+                ],
+              ),
+            ),
+          ] else ...[
+            Text(
+              'Save frequent places to prefill this search with one tap.',
+              style: TextStyle(color: palette.textSecondary, height: 1.35),
+            ),
+          ],
           const SizedBox(height: AppSpacing.s),
           TextField(
             controller: _dateController,

--- a/wheels/lib/features/saved_destinations/data/cache/saved_destinations_distance_cache.dart
+++ b/wheels/lib/features/saved_destinations/data/cache/saved_destinations_distance_cache.dart
@@ -1,0 +1,64 @@
+import 'dart:collection';
+
+class SavedDestinationsDistanceCache {
+  SavedDestinationsDistanceCache({this.capacity = 64})
+    : assert(capacity > 0, 'capacity must be greater than zero.');
+
+  final int capacity;
+  final LinkedHashMap<String, double> _entries = LinkedHashMap<String, double>();
+
+  double? get({
+    required int destinationId,
+    required double latitude,
+    required double longitude,
+  }) {
+    final key = _buildKey(
+      destinationId: destinationId,
+      latitude: latitude,
+      longitude: longitude,
+    );
+    final value = _entries.remove(key);
+    if (value == null) {
+      return null;
+    }
+    _entries[key] = value;
+    return value;
+  }
+
+  void put({
+    required int destinationId,
+    required double latitude,
+    required double longitude,
+    required double distanceKm,
+  }) {
+    final key = _buildKey(
+      destinationId: destinationId,
+      latitude: latitude,
+      longitude: longitude,
+    );
+    _entries.remove(key);
+    _entries[key] = distanceKm;
+    if (_entries.length > capacity) {
+      _entries.remove(_entries.keys.first);
+    }
+  }
+
+  void invalidateDestination(int destinationId) {
+    final prefix = '$destinationId:';
+    _entries.removeWhere((key, _) => key.startsWith(prefix));
+  }
+
+  void clear() {
+    _entries.clear();
+  }
+
+  String _buildKey({
+    required int destinationId,
+    required double latitude,
+    required double longitude,
+  }) {
+    final latBucket = (latitude * 1000).round();
+    final lngBucket = (longitude * 1000).round();
+    return '$destinationId:$latBucket:$lngBucket';
+  }
+}

--- a/wheels/lib/features/saved_destinations/data/datasources/saved_destinations_local_datasource.dart
+++ b/wheels/lib/features/saved_destinations/data/datasources/saved_destinations_local_datasource.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+
+import 'package:sqflite/sqflite.dart';
+
+import '../models/saved_destination_model.dart';
+
+class SavedDestinationsLocalDataSource {
+  static const String _dbName = 'wheels_saved_destinations.db';
+  static const int _dbVersion = 1;
+  static const String _table = 'saved_destinations';
+
+  Database? _db;
+  final Map<String, StreamController<List<SavedDestinationModel>>> _controllers =
+      <String, StreamController<List<SavedDestinationModel>>>{};
+
+  Future<Database> _openDatabase() async {
+    if (_db != null && _db!.isOpen) {
+      return _db!;
+    }
+
+    final dbPath = await getDatabasesPath();
+    _db = await openDatabase(
+      '$dbPath/$_dbName',
+      version: _dbVersion,
+      onCreate: (db, version) async {
+        await db.execute('''
+          CREATE TABLE $_table (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            address TEXT NOT NULL,
+            lat REAL NOT NULL,
+            lng REAL NOT NULL,
+            created_at INTEGER NOT NULL,
+            last_used_at INTEGER NOT NULL,
+            use_count INTEGER NOT NULL,
+            remote_id TEXT,
+            thumbnail_url TEXT,
+            pending_sync INTEGER NOT NULL DEFAULT 0,
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(user_id, address)
+          )
+        ''');
+        await db.execute(
+          'CREATE INDEX idx_saved_destinations_recent '
+          'ON $_table(user_id, last_used_at DESC)',
+        );
+        await db.execute(
+          'CREATE INDEX idx_saved_destinations_count '
+          'ON $_table(user_id, use_count DESC)',
+        );
+      },
+    );
+    return _db!;
+  }
+
+  Stream<List<SavedDestinationModel>> watchDestinations(
+    String userId, {
+    SavedDestinationsLocalSort sort = SavedDestinationsLocalSort.recent,
+  }) async* {
+    final controller = _controllers.putIfAbsent(
+      '$userId:${sort.name}',
+      () => StreamController<List<SavedDestinationModel>>.broadcast(),
+    );
+    yield await loadDestinations(userId, sort: sort);
+    yield* controller.stream;
+  }
+
+  Future<List<SavedDestinationModel>> loadDestinations(
+    String userId, {
+    SavedDestinationsLocalSort sort = SavedDestinationsLocalSort.recent,
+    bool includeDeleted = false,
+  }) async {
+    final db = await _openDatabase();
+    final rows = await db.query(
+      _table,
+      where: includeDeleted
+          ? 'user_id = ?'
+          : 'user_id = ? AND is_deleted = 0',
+      whereArgs: [userId],
+      orderBy: sort == SavedDestinationsLocalSort.recent
+          ? 'last_used_at DESC'
+          : 'use_count DESC, last_used_at DESC',
+    );
+    return rows.map(SavedDestinationModel.fromSqlite).toList(growable: false);
+  }
+
+  Future<SavedDestinationModel?> loadDestinationById(
+    String userId,
+    int localId,
+  ) async {
+    final db = await _openDatabase();
+    final rows = await db.query(
+      _table,
+      where: 'user_id = ? AND id = ?',
+      whereArgs: [userId, localId],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return SavedDestinationModel.fromSqlite(rows.first);
+  }
+
+  Future<SavedDestinationModel> upsertDestination(
+    SavedDestinationModel destination,
+  ) async {
+    final db = await _openDatabase();
+    if (destination.localId == null) {
+      await db.insert(
+        _table,
+        destination.toSqlite()..remove('id'),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+      final rows = await db.query(
+        _table,
+        where: 'user_id = ? AND address = ?',
+        whereArgs: [destination.userId, destination.address],
+        limit: 1,
+      );
+      final saved = SavedDestinationModel.fromSqlite(rows.first);
+      await _emitUser(destination.userId);
+      return saved;
+    }
+
+    await db.update(
+      _table,
+      destination.toSqlite()..remove('id'),
+      where: 'id = ? AND user_id = ?',
+      whereArgs: [destination.localId, destination.userId],
+    );
+    final saved = await loadDestinationById(destination.userId, destination.localId!);
+    await _emitUser(destination.userId);
+    return saved!;
+  }
+
+  Future<void> markDestinationDeleted({
+    required String userId,
+    required int localId,
+  }) async {
+    final db = await _openDatabase();
+    await db.update(
+      _table,
+      <String, Object?>{
+        'is_deleted': 1,
+        'pending_sync': 1,
+        'last_used_at': DateTime.now().toUtc().millisecondsSinceEpoch,
+      },
+      where: 'id = ? AND user_id = ?',
+      whereArgs: [localId, userId],
+    );
+    await _emitUser(userId);
+  }
+
+  Future<List<SavedDestinationModel>> loadPendingSync(String userId) async {
+    final db = await _openDatabase();
+    final rows = await db.query(
+      _table,
+      where: 'user_id = ? AND pending_sync = 1',
+      whereArgs: [userId],
+      orderBy: 'last_used_at ASC',
+    );
+    return rows.map(SavedDestinationModel.fromSqlite).toList(growable: false);
+  }
+
+  Future<void> markSynced({
+    required String userId,
+    required int localId,
+    String? remoteId,
+  }) async {
+    final db = await _openDatabase();
+    await db.update(
+      _table,
+      <String, Object?>{
+        'pending_sync': 0,
+        'remote_id': remoteId,
+      },
+      where: 'id = ? AND user_id = ?',
+      whereArgs: [localId, userId],
+    );
+    await _emitUser(userId);
+  }
+
+  Future<void> hardDelete({
+    required String userId,
+    required int localId,
+  }) async {
+    final db = await _openDatabase();
+    await db.delete(
+      _table,
+      where: 'id = ? AND user_id = ?',
+      whereArgs: [localId, userId],
+    );
+    await _emitUser(userId);
+  }
+
+  Future<void> _emitUser(String userId) async {
+    for (final sort in SavedDestinationsLocalSort.values) {
+      final key = '$userId:${sort.name}';
+      final controller = _controllers[key];
+      if (controller != null && !controller.isClosed) {
+        controller.add(await loadDestinations(userId, sort: sort));
+      }
+    }
+  }
+
+  Future<void> dispose() async {
+    for (final controller in _controllers.values) {
+      await controller.close();
+    }
+    _controllers.clear();
+    await _db?.close();
+    _db = null;
+  }
+}
+
+enum SavedDestinationsLocalSort { recent, useCount }

--- a/wheels/lib/features/saved_destinations/data/datasources/saved_destinations_preferences_local_datasource.dart
+++ b/wheels/lib/features/saved_destinations/data/datasources/saved_destinations_preferences_local_datasource.dart
@@ -1,0 +1,22 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SavedDestinationsPreferencesLocalDataSource {
+  const SavedDestinationsPreferencesLocalDataSource();
+
+  Future<int?> loadLastQuickPick(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_lastQuickPickKey(userId));
+  }
+
+  Future<void> saveLastQuickPick({
+    required String userId,
+    required int localId,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_lastQuickPickKey(userId), localId);
+  }
+
+  String _lastQuickPickKey(String userId) {
+    return 'saved_destinations_last_pick:$userId';
+  }
+}

--- a/wheels/lib/features/saved_destinations/data/datasources/saved_destinations_remote_datasource.dart
+++ b/wheels/lib/features/saved_destinations/data/datasources/saved_destinations_remote_datasource.dart
@@ -1,0 +1,36 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/saved_destination_model.dart';
+
+class SavedDestinationsRemoteDataSource {
+  const SavedDestinationsRemoteDataSource({required FirebaseFirestore firestore})
+    : _firestore = firestore;
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _collection(String userId) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('saved_destinations');
+  }
+
+  Future<String> upsertDestination(SavedDestinationModel destination) async {
+    final collection = _collection(destination.userId);
+    final document = destination.remoteId == null
+        ? collection.doc()
+        : collection.doc(destination.remoteId);
+    await document.set(
+      destination.toRemoteJson().cast<String, dynamic>(),
+      SetOptions(merge: true),
+    );
+    return document.id;
+  }
+
+  Future<void> deleteDestination({
+    required String userId,
+    required String remoteId,
+  }) async {
+    await _collection(userId).doc(remoteId).delete();
+  }
+}

--- a/wheels/lib/features/saved_destinations/data/isolates/distance_batch_isolate.dart
+++ b/wheels/lib/features/saved_destinations/data/isolates/distance_batch_isolate.dart
@@ -1,0 +1,98 @@
+import 'dart:isolate';
+import 'dart:math' as math;
+
+import '../../domain/entities/saved_destination.dart';
+
+class DistanceBatchIsolate {
+  const DistanceBatchIsolate();
+
+  Future<Map<int, double>> computeDistances({
+    required double currentLatitude,
+    required double currentLongitude,
+    required List<SavedDestination> destinations,
+  }) async {
+    if (destinations.isEmpty) {
+      return const <int, double>{};
+    }
+
+    final receivePort = ReceivePort();
+    await Isolate.spawn<_DistanceBatchMessage>(
+      _distanceBatchEntryPoint,
+      _DistanceBatchMessage(
+        sendPort: receivePort.sendPort,
+        currentLatitude: currentLatitude,
+        currentLongitude: currentLongitude,
+        destinations: destinations
+            .where((destination) => destination.localId != null)
+            .map(
+              (destination) => <String, Object>{
+                'id': destination.localId!,
+                'lat': destination.latitude,
+                'lng': destination.longitude,
+              },
+            )
+            .toList(growable: false),
+      ),
+    );
+
+    final message = await receivePort.first;
+    receivePort.close();
+
+    final rawResults = (message as Map<Object?, Object?>)
+        .cast<int, double>();
+    return rawResults;
+  }
+}
+
+class _DistanceBatchMessage {
+  const _DistanceBatchMessage({
+    required this.sendPort,
+    required this.currentLatitude,
+    required this.currentLongitude,
+    required this.destinations,
+  });
+
+  final SendPort sendPort;
+  final double currentLatitude;
+  final double currentLongitude;
+  final List<Map<String, Object>> destinations;
+}
+
+void _distanceBatchEntryPoint(_DistanceBatchMessage message) {
+  final results = <int, double>{};
+  for (final destination in message.destinations) {
+    final id = destination['id'] as int;
+    final latitude = (destination['lat'] as num).toDouble();
+    final longitude = (destination['lng'] as num).toDouble();
+    results[id] = _haversineKm(
+      message.currentLatitude,
+      message.currentLongitude,
+      latitude,
+      longitude,
+    );
+  }
+  message.sendPort.send(results);
+}
+
+double _haversineKm(
+  double startLatitude,
+  double startLongitude,
+  double endLatitude,
+  double endLongitude,
+) {
+  const earthRadiusKm = 6371.0;
+  final deltaLatitude = _toRadians(endLatitude - startLatitude);
+  final deltaLongitude = _toRadians(endLongitude - startLongitude);
+  final startLatRadians = _toRadians(startLatitude);
+  final endLatRadians = _toRadians(endLatitude);
+
+  final a =
+      math.pow(math.sin(deltaLatitude / 2), 2).toDouble() +
+      math.cos(startLatRadians) *
+          math.cos(endLatRadians) *
+          math.pow(math.sin(deltaLongitude / 2), 2).toDouble();
+  final c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
+  return earthRadiusKm * c;
+}
+
+double _toRadians(double degrees) => degrees * (math.pi / 180.0);

--- a/wheels/lib/features/saved_destinations/data/models/saved_destination_model.dart
+++ b/wheels/lib/features/saved_destinations/data/models/saved_destination_model.dart
@@ -1,0 +1,160 @@
+import '../../domain/entities/saved_destination.dart';
+
+class SavedDestinationModel extends SavedDestination {
+  const SavedDestinationModel({
+    super.localId,
+    required super.userId,
+    required super.name,
+    required super.address,
+    required super.latitude,
+    required super.longitude,
+    required super.createdAt,
+    required super.lastUsedAt,
+    required super.useCount,
+    super.remoteId,
+    super.thumbnailUrl,
+    super.pendingSync,
+    super.isDeleted,
+  });
+
+  factory SavedDestinationModel.create({
+    int? localId,
+    required String userId,
+    required String name,
+    required String address,
+    required double latitude,
+    required double longitude,
+    String? remoteId,
+    String? thumbnailUrl,
+    bool pendingSync = true,
+    bool isDeleted = false,
+    DateTime? createdAt,
+    DateTime? lastUsedAt,
+    int useCount = 0,
+  }) {
+    final now = DateTime.now().toUtc();
+    return SavedDestinationModel(
+      localId: localId,
+      userId: userId,
+      name: name,
+      address: address,
+      latitude: latitude,
+      longitude: longitude,
+      createdAt: createdAt ?? now,
+      lastUsedAt: lastUsedAt ?? now,
+      useCount: useCount,
+      remoteId: remoteId,
+      thumbnailUrl: thumbnailUrl,
+      pendingSync: pendingSync,
+      isDeleted: isDeleted,
+    );
+  }
+
+  factory SavedDestinationModel.fromEntity(SavedDestination entity) {
+    return SavedDestinationModel(
+      localId: entity.localId,
+      userId: entity.userId,
+      name: entity.name,
+      address: entity.address,
+      latitude: entity.latitude,
+      longitude: entity.longitude,
+      createdAt: entity.createdAt,
+      lastUsedAt: entity.lastUsedAt,
+      useCount: entity.useCount,
+      remoteId: entity.remoteId,
+      thumbnailUrl: entity.thumbnailUrl,
+      pendingSync: entity.pendingSync,
+      isDeleted: entity.isDeleted,
+    );
+  }
+
+  factory SavedDestinationModel.fromSqlite(Map<String, Object?> row) {
+    return SavedDestinationModel(
+      localId: row['id'] as int?,
+      userId: row['user_id'] as String,
+      name: row['name'] as String,
+      address: row['address'] as String,
+      latitude: (row['lat'] as num).toDouble(),
+      longitude: (row['lng'] as num).toDouble(),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        row['created_at'] as int,
+        isUtc: true,
+      ),
+      lastUsedAt: DateTime.fromMillisecondsSinceEpoch(
+        row['last_used_at'] as int,
+        isUtc: true,
+      ),
+      useCount: row['use_count'] as int,
+      remoteId: row['remote_id'] as String?,
+      thumbnailUrl: row['thumbnail_url'] as String?,
+      pendingSync: (row['pending_sync'] as int? ?? 0) == 1,
+      isDeleted: (row['is_deleted'] as int? ?? 0) == 1,
+    );
+  }
+
+  Map<String, Object?> toSqlite() {
+    return <String, Object?>{
+      'id': localId,
+      'user_id': userId,
+      'name': name,
+      'address': address,
+      'lat': latitude,
+      'lng': longitude,
+      'created_at': createdAt.toUtc().millisecondsSinceEpoch,
+      'last_used_at': lastUsedAt.toUtc().millisecondsSinceEpoch,
+      'use_count': useCount,
+      'remote_id': remoteId,
+      'thumbnail_url': thumbnailUrl,
+      'pending_sync': pendingSync ? 1 : 0,
+      'is_deleted': isDeleted ? 1 : 0,
+    };
+  }
+
+  Map<String, Object?> toRemoteJson() {
+    return <String, Object?>{
+      'userId': userId,
+      'name': name,
+      'address': address,
+      'normalizedAddress': address.trim().toLowerCase(),
+      'lat': latitude,
+      'lng': longitude,
+      'createdAt': createdAt.toUtc().millisecondsSinceEpoch,
+      'lastUsedAt': lastUsedAt.toUtc().millisecondsSinceEpoch,
+      'useCount': useCount,
+      'thumbnailUrl': thumbnailUrl,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  SavedDestinationModel copyModelWith({
+    int? localId,
+    String? userId,
+    String? name,
+    String? address,
+    double? latitude,
+    double? longitude,
+    DateTime? createdAt,
+    DateTime? lastUsedAt,
+    int? useCount,
+    String? remoteId,
+    String? thumbnailUrl,
+    bool? pendingSync,
+    bool? isDeleted,
+  }) {
+    return SavedDestinationModel(
+      localId: localId ?? this.localId,
+      userId: userId ?? this.userId,
+      name: name ?? this.name,
+      address: address ?? this.address,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+      createdAt: createdAt ?? this.createdAt,
+      lastUsedAt: lastUsedAt ?? this.lastUsedAt,
+      useCount: useCount ?? this.useCount,
+      remoteId: remoteId ?? this.remoteId,
+      thumbnailUrl: thumbnailUrl ?? this.thumbnailUrl,
+      pendingSync: pendingSync ?? this.pendingSync,
+      isDeleted: isDeleted ?? this.isDeleted,
+    );
+  }
+}

--- a/wheels/lib/features/saved_destinations/data/repositories/saved_destinations_repository_impl.dart
+++ b/wheels/lib/features/saved_destinations/data/repositories/saved_destinations_repository_impl.dart
@@ -1,0 +1,270 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../ride_history/data/datasources/ride_history_local_datasource.dart';
+import '../../../ride_history/domain/entities/ride_history_entity.dart';
+import '../../domain/entities/saved_destination.dart';
+import '../../domain/repositories/saved_destinations_repository.dart';
+import '../cache/saved_destinations_distance_cache.dart';
+import '../datasources/saved_destinations_local_datasource.dart';
+import '../datasources/saved_destinations_preferences_local_datasource.dart';
+import '../datasources/saved_destinations_remote_datasource.dart';
+import '../isolates/distance_batch_isolate.dart';
+import '../models/saved_destination_model.dart';
+
+class SavedDestinationsRepositoryImpl implements SavedDestinationsRepository {
+  const SavedDestinationsRepositoryImpl({
+    required SavedDestinationsLocalDataSource localDataSource,
+    required SavedDestinationsRemoteDataSource remoteDataSource,
+    required SavedDestinationsPreferencesLocalDataSource preferencesDataSource,
+    required SavedDestinationsDistanceCache distanceCache,
+    required DistanceBatchIsolate distanceBatchIsolate,
+    required RideHistoryLocalDataSource rideHistoryLocalDataSource,
+  }) : _localDataSource = localDataSource,
+       _remoteDataSource = remoteDataSource,
+       _preferencesDataSource = preferencesDataSource,
+       _distanceCache = distanceCache,
+       _distanceBatchIsolate = distanceBatchIsolate,
+       _rideHistoryLocalDataSource = rideHistoryLocalDataSource;
+
+  final SavedDestinationsLocalDataSource _localDataSource;
+  final SavedDestinationsRemoteDataSource _remoteDataSource;
+  final SavedDestinationsPreferencesLocalDataSource _preferencesDataSource;
+  final SavedDestinationsDistanceCache _distanceCache;
+  final DistanceBatchIsolate _distanceBatchIsolate;
+  final RideHistoryLocalDataSource _rideHistoryLocalDataSource;
+
+  @override
+  Stream<List<SavedDestination>> watchDestinations(
+    String userId, {
+    SavedDestinationsSort sort = SavedDestinationsSort.recent,
+  }) {
+    return _localDataSource.watchDestinations(
+      userId,
+      sort: _mapSort(sort),
+    );
+  }
+
+  @override
+  Future<List<SavedDestination>> loadDestinations(
+    String userId, {
+    SavedDestinationsSort sort = SavedDestinationsSort.recent,
+  }) {
+    return _localDataSource.loadDestinations(userId, sort: _mapSort(sort));
+  }
+
+  @override
+  Future<SavedDestination?> loadDestinationById(String userId, int localId) {
+    return _localDataSource.loadDestinationById(userId, localId);
+  }
+
+  @override
+  Future<SavedDestination> saveDestination(SavedDestination destination) async {
+    final model = SavedDestinationModel.fromEntity(destination).copyModelWith(
+      pendingSync: true,
+      isDeleted: false,
+    );
+    return _localDataSource.upsertDestination(model);
+  }
+
+  @override
+  Future<void> markDestinationDeleted({
+    required String userId,
+    required int localId,
+  }) async {
+    _distanceCache.invalidateDestination(localId);
+    await _localDataSource.markDestinationDeleted(userId: userId, localId: localId);
+  }
+
+  @override
+  Future<SavedDestination?> loadLastQuickPick(String userId) async {
+    final localId = await _preferencesDataSource.loadLastQuickPick(userId);
+    if (localId == null) {
+      return null;
+    }
+    final destination = await _localDataSource.loadDestinationById(userId, localId);
+    if (destination == null || destination.isDeleted) {
+      return null;
+    }
+    return destination;
+  }
+
+  @override
+  Future<void> saveLastQuickPick({
+    required String userId,
+    required int localId,
+  }) async {
+    await _preferencesDataSource.saveLastQuickPick(
+      userId: userId,
+      localId: localId,
+    );
+
+    final destination = await _localDataSource.loadDestinationById(userId, localId);
+    if (destination == null) {
+      return;
+    }
+
+    final updated = destination.copyModelWith(
+      useCount: destination.useCount + 1,
+      lastUsedAt: DateTime.now().toUtc(),
+      pendingSync: true,
+    );
+    await _localDataSource.upsertDestination(updated);
+  }
+
+  @override
+  Future<Map<int, double>> loadDistancesForCurrentLocation({
+    required double currentLatitude,
+    required double currentLongitude,
+    required List<SavedDestination> destinations,
+  }) async {
+    final resolved = <int, double>{};
+    final pending = <SavedDestination>[];
+
+    for (final destination in destinations) {
+      final localId = destination.localId;
+      if (localId == null) {
+        continue;
+      }
+
+      final cached = _distanceCache.get(
+        destinationId: localId,
+        latitude: currentLatitude,
+        longitude: currentLongitude,
+      );
+      if (cached != null) {
+        resolved[localId] = cached;
+      } else {
+        pending.add(destination);
+      }
+    }
+
+    if (pending.isNotEmpty) {
+      final computed = await _distanceBatchIsolate.computeDistances(
+        currentLatitude: currentLatitude,
+        currentLongitude: currentLongitude,
+        destinations: pending,
+      );
+      for (final entry in computed.entries) {
+        _distanceCache.put(
+          destinationId: entry.key,
+          latitude: currentLatitude,
+          longitude: currentLongitude,
+          distanceKm: entry.value,
+        );
+        resolved[entry.key] = entry.value;
+      }
+    }
+
+    return resolved;
+  }
+
+  @override
+  Future<SavedDestinationUsageStats> loadUsageStats({
+    required String userId,
+    required SavedDestination destination,
+  }) async {
+    final history = await _rideHistoryLocalDataSource.loadHistory(userId);
+    final matching = history
+        .where((entry) => _matchesDestination(entry, destination))
+        .toList(growable: false);
+    if (matching.isEmpty) {
+      return SavedDestinationUsageStats.empty;
+    }
+
+    final lastVisits = matching.take(5).map((entry) {
+      final date = entry.departureAt.toLocal();
+      final day = date.day.toString().padLeft(2, '0');
+      final month = date.month.toString().padLeft(2, '0');
+      return '$day/$month ${entry.origin}';
+    }).toList(growable: false);
+
+    final averagePrice =
+        matching.fold<int>(0, (sum, entry) => sum + entry.pricePerSeat) /
+        matching.length;
+
+    return SavedDestinationUsageStats(
+      totalRideCount: matching.length,
+      averagePricePerSeat: averagePrice,
+      lastVisitLabels: lastVisits,
+    );
+  }
+
+  @override
+  Future<void> syncPending(String userId) async {
+    final pending = await _localDataSource.loadPendingSync(userId);
+    if (pending.isEmpty) {
+      return;
+    }
+
+    final encodedBatch = await compute(
+      _encodePendingSyncBatch,
+      pending.map((item) => item.toRemoteJson()).toList(growable: false),
+    );
+    final encodedByNormalized = <String, Map<String, Object?>>{
+      for (final map in encodedBatch)
+        map['normalizedAddress'] as String: map,
+    };
+
+    for (final destination in pending) {
+      if (destination.localId == null) {
+        continue;
+      }
+
+      if (destination.isDeleted) {
+        if (destination.remoteId != null) {
+          await _remoteDataSource.deleteDestination(
+            userId: userId,
+            remoteId: destination.remoteId!,
+          );
+        }
+        await _localDataSource.hardDelete(
+          userId: userId,
+          localId: destination.localId!,
+        );
+        continue;
+      }
+
+      final normalizedAddress = destination.address.trim().toLowerCase();
+      final remotePayload = encodedByNormalized[normalizedAddress];
+      final syncedRemoteId = await _remoteDataSource.upsertDestination(
+        destination.copyModelWith(
+          pendingSync: false,
+          remoteId: destination.remoteId,
+          name: remotePayload?['name'] as String? ?? destination.name,
+        ),
+      );
+      await _localDataSource.markSynced(
+        userId: userId,
+        localId: destination.localId!,
+        remoteId: syncedRemoteId,
+      );
+    }
+  }
+
+  SavedDestinationsLocalSort _mapSort(SavedDestinationsSort sort) {
+    return sort == SavedDestinationsSort.recent
+        ? SavedDestinationsLocalSort.recent
+        : SavedDestinationsLocalSort.useCount;
+  }
+
+  bool _matchesDestination(
+    RideHistoryEntity entry,
+    SavedDestination destination,
+  ) {
+    final normalizedEntryDestination = entry.destination.trim().toLowerCase();
+    final normalizedSavedAddress = destination.address.trim().toLowerCase();
+    final normalizedSavedName = destination.name.trim().toLowerCase();
+    return normalizedEntryDestination.contains(normalizedSavedAddress) ||
+        normalizedEntryDestination.contains(normalizedSavedName);
+  }
+}
+
+List<Map<String, Object?>> _encodePendingSyncBatch(
+  List<Map<String, Object?>> batch,
+) {
+  return batch
+      .map((item) => Map<String, Object?>.from(item))
+      .toList(growable: false);
+}

--- a/wheels/lib/features/saved_destinations/data/repositories/saved_destinations_repository_impl.dart
+++ b/wheels/lib/features/saved_destinations/data/repositories/saved_destinations_repository_impl.dart
@@ -124,7 +124,7 @@ class SavedDestinationsRepositoryImpl implements SavedDestinationsRepository {
 
     for (final destination in destinations) {
       final localId = destination.localId;
-      if (localId == null) {
+      if (localId == null || !destination.hasResolvedCoordinates) {
         continue;
       }
 

--- a/wheels/lib/features/saved_destinations/data/sync/saved_destinations_sync_worker.dart
+++ b/wheels/lib/features/saved_destinations/data/sync/saved_destinations_sync_worker.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import '../../domain/repositories/saved_destinations_repository.dart';
+
+class SavedDestinationsSyncWorker {
+  SavedDestinationsSyncWorker({
+    required SavedDestinationsRepository repository,
+    required Stream<bool> connectivityStream,
+    required String Function() currentUserId,
+  }) : _repository = repository,
+       _connectivityStream = connectivityStream,
+       _currentUserId = currentUserId;
+
+  final SavedDestinationsRepository _repository;
+  final Stream<bool> _connectivityStream;
+  final String Function() _currentUserId;
+
+  StreamSubscription<bool>? _subscription;
+  bool _isSyncing = false;
+
+  void start() {
+    _subscription ??= _connectivityStream.listen((isOnline) async {
+      if (!isOnline || _isSyncing) {
+        return;
+      }
+
+      final userId = _currentUserId();
+      if (userId.isEmpty) {
+        return;
+      }
+
+      _isSyncing = true;
+      try {
+        await _repository.syncPending(userId);
+      } finally {
+        _isSyncing = false;
+      }
+    });
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}

--- a/wheels/lib/features/saved_destinations/domain/entities/saved_destination.dart
+++ b/wheels/lib/features/saved_destinations/domain/entities/saved_destination.dart
@@ -1,0 +1,86 @@
+class SavedDestination {
+  const SavedDestination({
+    this.localId,
+    required this.userId,
+    required this.name,
+    required this.address,
+    required this.latitude,
+    required this.longitude,
+    required this.createdAt,
+    required this.lastUsedAt,
+    required this.useCount,
+    this.remoteId,
+    this.thumbnailUrl,
+    this.pendingSync = false,
+    this.isDeleted = false,
+  });
+
+  final int? localId;
+  final String userId;
+  final String name;
+  final String address;
+  final double latitude;
+  final double longitude;
+  final DateTime createdAt;
+  final DateTime lastUsedAt;
+  final int useCount;
+  final String? remoteId;
+  final String? thumbnailUrl;
+  final bool pendingSync;
+  final bool isDeleted;
+
+  String get displayLabel => name.trim().isEmpty ? address : name.trim();
+
+  String get coordinatesLabel =>
+      '${latitude.toStringAsFixed(5)}, ${longitude.toStringAsFixed(5)}';
+
+  SavedDestination copyWith({
+    int? localId,
+    String? userId,
+    String? name,
+    String? address,
+    double? latitude,
+    double? longitude,
+    DateTime? createdAt,
+    DateTime? lastUsedAt,
+    int? useCount,
+    String? remoteId,
+    String? thumbnailUrl,
+    bool? pendingSync,
+    bool? isDeleted,
+  }) {
+    return SavedDestination(
+      localId: localId ?? this.localId,
+      userId: userId ?? this.userId,
+      name: name ?? this.name,
+      address: address ?? this.address,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+      createdAt: createdAt ?? this.createdAt,
+      lastUsedAt: lastUsedAt ?? this.lastUsedAt,
+      useCount: useCount ?? this.useCount,
+      remoteId: remoteId ?? this.remoteId,
+      thumbnailUrl: thumbnailUrl ?? this.thumbnailUrl,
+      pendingSync: pendingSync ?? this.pendingSync,
+      isDeleted: isDeleted ?? this.isDeleted,
+    );
+  }
+}
+
+class SavedDestinationUsageStats {
+  const SavedDestinationUsageStats({
+    required this.totalRideCount,
+    required this.averagePricePerSeat,
+    required this.lastVisitLabels,
+  });
+
+  final int totalRideCount;
+  final double averagePricePerSeat;
+  final List<String> lastVisitLabels;
+
+  static const empty = SavedDestinationUsageStats(
+    totalRideCount: 0,
+    averagePricePerSeat: 0,
+    lastVisitLabels: <String>[],
+  );
+}

--- a/wheels/lib/features/saved_destinations/domain/entities/saved_destination.dart
+++ b/wheels/lib/features/saved_destinations/domain/entities/saved_destination.dart
@@ -31,8 +31,12 @@ class SavedDestination {
 
   String get displayLabel => name.trim().isEmpty ? address : name.trim();
 
+  bool get hasResolvedCoordinates => latitude != 0 || longitude != 0;
+
   String get coordinatesLabel =>
-      '${latitude.toStringAsFixed(5)}, ${longitude.toStringAsFixed(5)}';
+      hasResolvedCoordinates
+          ? '${latitude.toStringAsFixed(5)}, ${longitude.toStringAsFixed(5)}'
+          : 'Coordinates pending';
 
   SavedDestination copyWith({
     int? localId,

--- a/wheels/lib/features/saved_destinations/domain/repositories/saved_destinations_repository.dart
+++ b/wheels/lib/features/saved_destinations/domain/repositories/saved_destinations_repository.dart
@@ -1,0 +1,44 @@
+import '../entities/saved_destination.dart';
+
+abstract class SavedDestinationsRepository {
+  Stream<List<SavedDestination>> watchDestinations(
+    String userId, {
+    SavedDestinationsSort sort = SavedDestinationsSort.recent,
+  });
+
+  Future<List<SavedDestination>> loadDestinations(
+    String userId, {
+    SavedDestinationsSort sort = SavedDestinationsSort.recent,
+  });
+
+  Future<SavedDestination?> loadDestinationById(String userId, int localId);
+
+  Future<SavedDestination> saveDestination(SavedDestination destination);
+
+  Future<void> markDestinationDeleted({
+    required String userId,
+    required int localId,
+  });
+
+  Future<SavedDestination?> loadLastQuickPick(String userId);
+
+  Future<void> saveLastQuickPick({
+    required String userId,
+    required int localId,
+  });
+
+  Future<Map<int, double>> loadDistancesForCurrentLocation({
+    required double currentLatitude,
+    required double currentLongitude,
+    required List<SavedDestination> destinations,
+  });
+
+  Future<SavedDestinationUsageStats> loadUsageStats({
+    required String userId,
+    required SavedDestination destination,
+  });
+
+  Future<void> syncPending(String userId);
+}
+
+enum SavedDestinationsSort { recent, useCount }

--- a/wheels/lib/features/saved_destinations/presentation/providers/saved_destinations_providers.dart
+++ b/wheels/lib/features/saved_destinations/presentation/providers/saved_destinations_providers.dart
@@ -1,0 +1,240 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart';
+
+import '../../../../shared/providers/connectivity_provider.dart';
+import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../../ride_history/presentation/providers/ride_history_providers.dart';
+import '../../data/cache/saved_destinations_distance_cache.dart';
+import '../../data/datasources/saved_destinations_local_datasource.dart';
+import '../../data/datasources/saved_destinations_preferences_local_datasource.dart';
+import '../../data/datasources/saved_destinations_remote_datasource.dart';
+import '../../data/isolates/distance_batch_isolate.dart';
+import '../../data/repositories/saved_destinations_repository_impl.dart';
+import '../../data/sync/saved_destinations_sync_worker.dart';
+import '../../domain/entities/saved_destination.dart';
+import '../../domain/repositories/saved_destinations_repository.dart';
+
+final savedDestinationsFirestoreProvider = Provider<FirebaseFirestore>((ref) {
+  return FirebaseFirestore.instance;
+});
+
+final savedDestinationsLocalDataSourceProvider =
+    Provider<SavedDestinationsLocalDataSource>((ref) {
+      final ds = SavedDestinationsLocalDataSource();
+      ref.onDispose(() => ds.dispose());
+      return ds;
+    });
+
+final savedDestinationsPreferencesProvider =
+    Provider<SavedDestinationsPreferencesLocalDataSource>((ref) {
+      return const SavedDestinationsPreferencesLocalDataSource();
+    });
+
+final savedDestinationsRemoteDataSourceProvider =
+    Provider<SavedDestinationsRemoteDataSource>((ref) {
+      return SavedDestinationsRemoteDataSource(
+        firestore: ref.watch(savedDestinationsFirestoreProvider),
+      );
+    });
+
+final savedDestinationsDistanceCacheProvider =
+    Provider<SavedDestinationsDistanceCache>((ref) {
+      final cache = SavedDestinationsDistanceCache();
+      ref.onDispose(cache.clear);
+      return cache;
+    });
+
+final savedDestinationsDistanceIsolateProvider =
+    Provider<DistanceBatchIsolate>((ref) {
+      return const DistanceBatchIsolate();
+    });
+
+final savedDestinationsRepositoryProvider =
+    Provider<SavedDestinationsRepository>((ref) {
+      return SavedDestinationsRepositoryImpl(
+        localDataSource: ref.watch(savedDestinationsLocalDataSourceProvider),
+        remoteDataSource: ref.watch(savedDestinationsRemoteDataSourceProvider),
+        preferencesDataSource: ref.watch(savedDestinationsPreferencesProvider),
+        distanceCache: ref.watch(savedDestinationsDistanceCacheProvider),
+        distanceBatchIsolate: ref.watch(savedDestinationsDistanceIsolateProvider),
+        rideHistoryLocalDataSource: ref.watch(rideHistoryLocalDataSourceProvider),
+      );
+    });
+
+final savedDestinationsCurrentUserIdProvider = Provider<String?>((ref) {
+  return ref.watch(authUserProvider)?.uid;
+});
+
+final savedDestinationsSortProvider =
+    StateProvider<SavedDestinationsSort>((ref) {
+      return SavedDestinationsSort.recent;
+    });
+
+final savedDestinationsStreamProvider =
+    StreamProvider.autoDispose<List<SavedDestination>>((ref) {
+      final userId = ref.watch(savedDestinationsCurrentUserIdProvider);
+      if (userId == null) {
+        return Stream<List<SavedDestination>>.value(const <SavedDestination>[]);
+      }
+      final sort = ref.watch(savedDestinationsSortProvider);
+      return ref
+          .watch(savedDestinationsRepositoryProvider)
+          .watchDestinations(userId, sort: sort);
+    });
+
+final savedDestinationsLastQuickPickProvider =
+    FutureProvider.autoDispose<SavedDestination?>((ref) async {
+      final userId = ref.watch(savedDestinationsCurrentUserIdProvider);
+      if (userId == null) {
+        return null;
+      }
+      return ref.watch(savedDestinationsRepositoryProvider).loadLastQuickPick(userId);
+    });
+
+final savedDestinationsCurrentPositionProvider =
+    FutureProvider.autoDispose<Position?>((ref) async {
+      final permission = await Geolocator.checkPermission();
+      var resolvedPermission = permission;
+      if (resolvedPermission == LocationPermission.denied) {
+        resolvedPermission = await Geolocator.requestPermission();
+      }
+      if (resolvedPermission == LocationPermission.denied ||
+          resolvedPermission == LocationPermission.deniedForever) {
+        return null;
+      }
+      final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        return null;
+      }
+      return Geolocator.getCurrentPosition(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.high,
+        ),
+      );
+    });
+
+class SavedDestinationsBootstrapData {
+  const SavedDestinationsBootstrapData({
+    required this.position,
+    required this.lastQuickPick,
+  });
+
+  final Position? position;
+  final SavedDestination? lastQuickPick;
+}
+
+class SavedDestinationTrendingEntry {
+  const SavedDestinationTrendingEntry({
+    required this.name,
+    required this.address,
+    required this.saveCount,
+  });
+
+  final String name;
+  final String address;
+  final int saveCount;
+}
+
+final savedDestinationsBootstrapProvider =
+    FutureProvider.autoDispose<SavedDestinationsBootstrapData>((ref) async {
+      final userId = ref.watch(savedDestinationsCurrentUserIdProvider);
+      if (userId == null) {
+        return const SavedDestinationsBootstrapData(
+          position: null,
+          lastQuickPick: null,
+        );
+      }
+
+      final results = await Future.wait<Object?>([
+        ref.watch(savedDestinationsCurrentPositionProvider.future),
+        ref.watch(savedDestinationsRepositoryProvider).loadLastQuickPick(userId),
+      ]);
+
+      return SavedDestinationsBootstrapData(
+        position: results[0] as Position?,
+        lastQuickPick: results[1] as SavedDestination?,
+      );
+    });
+
+final savedDestinationByIdProvider =
+    FutureProvider.autoDispose.family<SavedDestination?, int>((ref, localId) {
+      final userId = ref.watch(savedDestinationsCurrentUserIdProvider);
+      if (userId == null) {
+        return Future<SavedDestination?>.value(null);
+      }
+      return ref
+          .watch(savedDestinationsRepositoryProvider)
+          .loadDestinationById(userId, localId);
+    });
+
+final savedDestinationsTrendingProvider =
+    FutureProvider.autoDispose<List<SavedDestinationTrendingEntry>>((ref) async {
+      final snapshot = await ref
+          .watch(savedDestinationsFirestoreProvider)
+          .collectionGroup('saved_destinations')
+          .where('isDeleted', isEqualTo: false)
+          .limit(200)
+          .get();
+
+      final counts = <String, SavedDestinationTrendingEntry>{};
+      for (final doc in snapshot.docs) {
+        final data = doc.data();
+        final normalizedAddress =
+            (data['normalizedAddress'] as String? ?? '').trim().toLowerCase();
+        if (normalizedAddress.isEmpty) {
+          continue;
+        }
+
+        final existing = counts[normalizedAddress];
+        if (existing == null) {
+          counts[normalizedAddress] = SavedDestinationTrendingEntry(
+            name: (data['name'] as String? ?? data['address'] as String? ?? '')
+                .trim(),
+            address: (data['address'] as String? ?? '').trim(),
+            saveCount: 1,
+          );
+        } else {
+          counts[normalizedAddress] = SavedDestinationTrendingEntry(
+            name: existing.name,
+            address: existing.address,
+            saveCount: existing.saveCount + 1,
+          );
+        }
+      }
+
+      final entries = counts.values.toList(growable: false)
+        ..sort((left, right) => right.saveCount.compareTo(left.saveCount));
+      return entries.take(5).toList(growable: false);
+    });
+
+final savedDestinationsSyncWorkerProvider =
+    Provider<SavedDestinationsSyncWorker>((ref) {
+      final worker = SavedDestinationsSyncWorker(
+        repository: ref.watch(savedDestinationsRepositoryProvider),
+        connectivityStream:
+            ref.watch(connectivityServiceProvider).watchConnection(),
+        currentUserId: () => ref.read(savedDestinationsCurrentUserIdProvider) ?? '',
+      );
+      worker.start();
+      ref.onDispose(() => worker.dispose());
+      return worker;
+    });
+
+final savedDestinationsFeatureInitProvider = Provider<void>((ref) {
+  ref.watch(savedDestinationsSyncWorkerProvider);
+});
+
+@visibleForTesting
+SavedDestinationsBootstrapData debugSavedDestinationsBootstrapData({
+  Position? position,
+  SavedDestination? lastQuickPick,
+}) {
+  return SavedDestinationsBootstrapData(
+    position: position,
+    lastQuickPick: lastQuickPick,
+  );
+}

--- a/wheels/lib/features/saved_destinations/presentation/screens/saved_destination_detail_screen.dart
+++ b/wheels/lib/features/saved_destinations/presentation/screens/saved_destination_detail_screen.dart
@@ -279,7 +279,7 @@ class _DetailActions extends ConsumerWidget {
                 if (!context.mounted) {
                   return;
                 }
-                context.go(AppRoutes.rides);
+                context.go(AppRoutes.ridesWithSavedDestination(localId));
               },
               icon: const Icon(Icons.search),
               label: const Text('Plan in ride search'),
@@ -302,7 +302,7 @@ class _DetailActions extends ConsumerWidget {
                 if (!context.mounted) {
                   return;
                 }
-                context.go(AppRoutes.createRide);
+                context.go(AppRoutes.createRideWithSavedDestination(localId));
               },
               icon: const Icon(Icons.add_road_outlined),
               label: const Text('Use in create ride'),

--- a/wheels/lib/features/saved_destinations/presentation/screens/saved_destination_detail_screen.dart
+++ b/wheels/lib/features/saved_destinations/presentation/screens/saved_destination_detail_screen.dart
@@ -1,0 +1,394 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../router/app_routes.dart';
+import '../../../../theme/app_radius.dart';
+import '../../../../theme/app_shadows.dart';
+import '../../../../theme/app_spacing.dart';
+import '../../../../theme/app_theme_palette.dart';
+import '../../domain/entities/saved_destination.dart';
+import '../providers/saved_destinations_providers.dart';
+
+class SavedDestinationDetailScreen extends ConsumerWidget {
+  const SavedDestinationDetailScreen({required this.localId, super.key});
+
+  final int localId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final destinationAsync = ref.watch(savedDestinationByIdProvider(localId));
+    final bootstrapAsync = ref.watch(savedDestinationsBootstrapProvider);
+
+    return Scaffold(
+      backgroundColor: context.palette.background,
+      appBar: AppBar(
+        title: const Text('Destination detail'),
+      ),
+      body: destinationAsync.when(
+        data: (destination) {
+          if (destination == null) {
+            return const _DetailMissingState();
+          }
+
+          return ListView(
+            padding: const EdgeInsets.all(AppSpacing.m),
+            children: [
+              _HeroCard(destination: destination),
+              const SizedBox(height: AppSpacing.m),
+              _DistanceAndStats(
+                destination: destination,
+                currentPosition: bootstrapAsync.valueOrNull?.position,
+              ),
+              const SizedBox(height: AppSpacing.m),
+              _DetailActions(destination: destination),
+            ],
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text(error.toString())),
+      ),
+    );
+  }
+}
+
+class _HeroCard extends StatelessWidget {
+  const _HeroCard({required this.destination});
+
+  final SavedDestination destination;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.l),
+      decoration: BoxDecoration(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        boxShadow: AppShadows.md,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            destination.displayLabel,
+            style: TextStyle(
+              color: palette.textPrimary,
+              fontWeight: FontWeight.w800,
+              fontSize: 26,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Text(
+            destination.address,
+            style: TextStyle(
+              color: palette.textSecondary,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          Wrap(
+            spacing: AppSpacing.s,
+            runSpacing: AppSpacing.s,
+            children: [
+              _StatPill(label: '${destination.useCount} saved uses'),
+              _StatPill(label: destination.coordinatesLabel),
+              if (destination.pendingSync)
+                _StatPill(label: 'Pending sync'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DistanceAndStats extends ConsumerWidget {
+  const _DistanceAndStats({
+    required this.destination,
+    required this.currentPosition,
+  });
+
+  final SavedDestination destination;
+  final Position? currentPosition;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final palette = context.palette;
+    final userId = ref.watch(savedDestinationsCurrentUserIdProvider);
+    final position = currentPosition;
+    return FutureBuilder<List<Object?>>(
+      future: Future.wait<Object?>([
+        if (position != null && destination.localId != null)
+          ref.read(savedDestinationsRepositoryProvider).loadDistancesForCurrentLocation(
+                currentLatitude: position.latitude,
+                currentLongitude: position.longitude,
+                destinations: <SavedDestination>[destination],
+              )
+        else
+          Future<Map<int, double>>.value(const <int, double>{}),
+        if (userId != null)
+          ref.read(savedDestinationsRepositoryProvider).loadUsageStats(
+                userId: userId,
+                destination: destination,
+              )
+        else
+          Future<SavedDestinationUsageStats>.value(
+            SavedDestinationUsageStats.empty,
+          ),
+      ]),
+      builder: (context, snapshot) {
+        final distances = snapshot.data == null
+            ? const <int, double>{}
+            : snapshot.data![0] as Map<int, double>;
+        final stats = snapshot.data == null
+            ? SavedDestinationUsageStats.empty
+            : snapshot.data![1] as SavedDestinationUsageStats;
+        final distance = destination.localId == null
+            ? null
+            : distances[destination.localId!];
+
+        return Container(
+          padding: const EdgeInsets.all(AppSpacing.l),
+          decoration: BoxDecoration(
+            color: palette.card,
+            borderRadius: BorderRadius.circular(AppRadius.lg),
+            boxShadow: AppShadows.sm,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Trip planner snapshot',
+                style: TextStyle(
+                  color: palette.textPrimary,
+                  fontWeight: FontWeight.w800,
+                  fontSize: 20,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.m),
+              _InfoRow(
+                label: 'Distance from current location',
+                value: distance == null
+                    ? 'Location unavailable'
+                    : '${distance.toStringAsFixed(1)} km',
+              ),
+              _InfoRow(
+                label: 'Total ride count',
+                value: '${stats.totalRideCount}',
+              ),
+              _InfoRow(
+                label: 'Average price per seat',
+                value: stats.totalRideCount == 0
+                    ? 'No history yet'
+                    : '\$${stats.averagePricePerSeat.toStringAsFixed(0)} COP',
+              ),
+              const SizedBox(height: AppSpacing.m),
+              Text(
+                'Last 5 visits',
+                style: TextStyle(
+                  color: palette.textPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.s),
+              if (stats.lastVisitLabels.isEmpty)
+                Text(
+                  'No recent rides toward this destination were found in local history.',
+                  style: TextStyle(color: palette.textSecondary),
+                )
+              else
+                for (final visit in stats.lastVisitLabels)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(
+                          Icons.history,
+                          size: 16,
+                          color: palette.secondary,
+                        ),
+                        const SizedBox(width: AppSpacing.s),
+                        Expanded(
+                          child: Text(
+                            visit,
+                            style: TextStyle(color: palette.textSecondary),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DetailActions extends ConsumerWidget {
+  const _DetailActions({required this.destination});
+
+  final SavedDestination destination;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.l),
+      decoration: BoxDecoration(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        boxShadow: AppShadows.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Use this destination',
+            style: TextStyle(
+              color: palette.textPrimary,
+              fontWeight: FontWeight.w800,
+              fontSize: 20,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Text(
+            'Save it as your latest quick pick and jump directly into ride search or ride creation.',
+            style: TextStyle(
+              color: palette.textSecondary,
+              height: 1.35,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: () async {
+                final userId = ref.read(savedDestinationsCurrentUserIdProvider);
+                final localId = destination.localId;
+                if (userId == null || localId == null) {
+                  return;
+                }
+                await ref.read(savedDestinationsRepositoryProvider).saveLastQuickPick(
+                      userId: userId,
+                      localId: localId,
+                    );
+                if (!context.mounted) {
+                  return;
+                }
+                context.go(AppRoutes.rides);
+              },
+              icon: const Icon(Icons.search),
+              label: const Text('Plan in ride search'),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: () async {
+                final userId = ref.read(savedDestinationsCurrentUserIdProvider);
+                final localId = destination.localId;
+                if (userId == null || localId == null) {
+                  return;
+                }
+                await ref.read(savedDestinationsRepositoryProvider).saveLastQuickPick(
+                      userId: userId,
+                      localId: localId,
+                    );
+                if (!context.mounted) {
+                  return;
+                }
+                context.go(AppRoutes.createRide);
+              },
+              icon: const Icon(Icons.add_road_outlined),
+              label: const Text('Use in create ride'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.s),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: TextStyle(color: palette.textSecondary),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.s),
+          Text(
+            value,
+            style: TextStyle(
+              color: palette.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatPill extends StatelessWidget {
+  const _StatPill({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s,
+        vertical: 6,
+      ),
+      decoration: BoxDecoration(
+        color: palette.secondarySoft,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: palette.secondary,
+          fontWeight: FontWeight.w700,
+          fontSize: 12,
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailMissingState extends StatelessWidget {
+  const _DetailMissingState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.l),
+        child: Text(
+          'This saved destination is no longer available on this device.',
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/wheels/lib/features/saved_destinations/presentation/screens/saved_destinations_screen.dart
+++ b/wheels/lib/features/saved_destinations/presentation/screens/saved_destinations_screen.dart
@@ -57,13 +57,10 @@ class _SavedDestinationsScreenState
     }
 
     try {
-      final locations = await locationFromAddress(result.address);
-      final coordinates = locations.isEmpty
-          ? null
-          : locations.first;
-      if (coordinates == null) {
-        throw Exception('We could not resolve that address to map coordinates.');
-      }
+      final coordinates = await _resolveCoordinatesForDraft(
+        address: result.address.trim(),
+        existing: existing,
+      );
 
       final repository = ref.read(savedDestinationsRepositoryProvider);
       final destination = SavedDestination(
@@ -71,8 +68,8 @@ class _SavedDestinationsScreenState
         userId: userId,
         name: result.name.trim(),
         address: result.address.trim(),
-        latitude: coordinates.latitude,
-        longitude: coordinates.longitude,
+        latitude: coordinates.$1,
+        longitude: coordinates.$2,
         createdAt: existing?.createdAt ?? DateTime.now().toUtc(),
         lastUsedAt: existing?.lastUsedAt ?? DateTime.now().toUtc(),
         useCount: existing?.useCount ?? 0,
@@ -91,9 +88,13 @@ class _SavedDestinationsScreenState
         ..showSnackBar(
           SnackBar(
             content: Text(
-              existing == null
-                  ? 'Destination saved locally.'
-                  : 'Destination updated locally.',
+              coordinates.$3
+                  ? existing == null
+                        ? 'Destination saved locally.'
+                        : 'Destination updated locally.'
+                  : existing == null
+                  ? 'Destination saved locally without route coordinates. You can refine it later when online.'
+                  : 'Destination updated locally. Coordinates will need to be refreshed later.',
             ),
           ),
         );
@@ -107,6 +108,27 @@ class _SavedDestinationsScreenState
           SnackBar(content: Text(error.toString().replaceFirst('Exception: ', ''))),
         );
     }
+  }
+
+  Future<(double, double, bool)> _resolveCoordinatesForDraft({
+    required String address,
+    SavedDestination? existing,
+  }) async {
+    try {
+      final locations = await locationFromAddress(address);
+      if (locations.isNotEmpty) {
+        final coordinates = locations.first;
+        return (coordinates.latitude, coordinates.longitude, true);
+      }
+    } catch (_) {
+      // Fallback handled below to preserve offline-first local writes.
+    }
+
+    if (existing != null && existing.hasResolvedCoordinates) {
+      return (existing.latitude, existing.longitude, false);
+    }
+
+    return (0.0, 0.0, false);
   }
 
   Future<void> _deleteDestination(SavedDestination destination) async {
@@ -319,6 +341,8 @@ class _SavedDestinationsScreenState
                                           ),
                                         );
                                       },
+                                      onEdit: () =>
+                                          _openDestinationEditor(existing: destination),
                                       onDelete: () => _deleteDestination(destination),
                                     );
                                   },

--- a/wheels/lib/features/saved_destinations/presentation/screens/saved_destinations_screen.dart
+++ b/wheels/lib/features/saved_destinations/presentation/screens/saved_destinations_screen.dart
@@ -1,0 +1,811 @@
+import 'package:geocoding/geocoding.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../router/app_routes.dart';
+import '../../../../shared/services/current_location_service.dart';
+import '../../../../shared/widgets/app_bottom_nav.dart';
+import '../../../../shared/widgets/app_gradient_header.dart';
+import '../../../../theme/app_radius.dart';
+import '../../../../theme/app_shadows.dart';
+import '../../../../theme/app_spacing.dart';
+import '../../../../theme/app_theme_palette.dart';
+import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../domain/entities/saved_destination.dart';
+import '../../domain/repositories/saved_destinations_repository.dart';
+import '../providers/saved_destinations_providers.dart';
+import '../widgets/saved_destination_tile.dart';
+
+class SavedDestinationsScreen extends ConsumerStatefulWidget {
+  const SavedDestinationsScreen({super.key});
+
+  @override
+  ConsumerState<SavedDestinationsScreen> createState() =>
+      _SavedDestinationsScreenState();
+}
+
+class _SavedDestinationsScreenState
+    extends ConsumerState<SavedDestinationsScreen> {
+  final _currentLocationService = const CurrentLocationService();
+  bool _isAddingCurrentLocation = false;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      ref.read(savedDestinationsFeatureInitProvider);
+    });
+  }
+
+  Future<void> _openDestinationEditor({SavedDestination? existing}) async {
+    final result = await showModalBottomSheet<_SavedDestinationDraft>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => _SavedDestinationEditorSheet(existing: existing),
+    );
+
+    if (!mounted || result == null) {
+      return;
+    }
+
+    final userId = ref.read(savedDestinationsCurrentUserIdProvider);
+    if (userId == null) {
+      return;
+    }
+
+    try {
+      final locations = await locationFromAddress(result.address);
+      final coordinates = locations.isEmpty
+          ? null
+          : locations.first;
+      if (coordinates == null) {
+        throw Exception('We could not resolve that address to map coordinates.');
+      }
+
+      final repository = ref.read(savedDestinationsRepositoryProvider);
+      final destination = SavedDestination(
+        localId: existing?.localId,
+        userId: userId,
+        name: result.name.trim(),
+        address: result.address.trim(),
+        latitude: coordinates.latitude,
+        longitude: coordinates.longitude,
+        createdAt: existing?.createdAt ?? DateTime.now().toUtc(),
+        lastUsedAt: existing?.lastUsedAt ?? DateTime.now().toUtc(),
+        useCount: existing?.useCount ?? 0,
+        remoteId: existing?.remoteId,
+        thumbnailUrl: result.thumbnailUrl.trim().isEmpty
+            ? null
+            : result.thumbnailUrl.trim(),
+        pendingSync: true,
+      );
+      await repository.saveDestination(destination);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(
+              existing == null
+                  ? 'Destination saved locally.'
+                  : 'Destination updated locally.',
+            ),
+          ),
+        );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(content: Text(error.toString().replaceFirst('Exception: ', ''))),
+        );
+    }
+  }
+
+  Future<void> _deleteDestination(SavedDestination destination) async {
+    final userId = ref.read(savedDestinationsCurrentUserIdProvider);
+    if (userId == null || destination.localId == null) {
+      return;
+    }
+
+    await ref.read(savedDestinationsRepositoryProvider).markDestinationDeleted(
+      userId: userId,
+      localId: destination.localId!,
+    );
+
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(content: Text('${destination.displayLabel} removed locally.')),
+      );
+  }
+
+  Future<void> _addCurrentLocationQuickly() async {
+    if (_isAddingCurrentLocation) {
+      return;
+    }
+
+    setState(() {
+      _isAddingCurrentLocation = true;
+    });
+
+    try {
+      final userId = ref.read(savedDestinationsCurrentUserIdProvider);
+      if (userId == null) {
+        return;
+      }
+
+      final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        throw Exception('Enable location services first.');
+      }
+
+      var permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied) {
+        permission = await Geolocator.requestPermission();
+      }
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        throw Exception('Location permission is required to quick-save your current place.');
+      }
+
+      final position = await Geolocator.getCurrentPosition(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.high,
+        ),
+      );
+      final address = await _currentLocationService.getCurrentAddress();
+
+      await ref.read(savedDestinationsRepositoryProvider).saveDestination(
+        SavedDestination(
+          userId: userId,
+          name: 'Current location',
+          address: address,
+          latitude: position.latitude,
+          longitude: position.longitude,
+          createdAt: DateTime.now().toUtc(),
+          lastUsedAt: DateTime.now().toUtc(),
+          useCount: 0,
+          pendingSync: true,
+        ),
+      );
+
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(content: Text('Current location saved.')),
+        );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(content: Text(error.toString().replaceFirst('Exception: ', ''))),
+        );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isAddingCurrentLocation = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final role = ref.watch(currentUserRoleProvider);
+    final destinationsAsync = ref.watch(savedDestinationsStreamProvider);
+    final bootstrapAsync = ref.watch(savedDestinationsBootstrapProvider);
+    final trendingAsync = ref.watch(savedDestinationsTrendingProvider);
+    final selectedSort = ref.watch(savedDestinationsSortProvider);
+
+    return Scaffold(
+      backgroundColor: palette.background,
+      bottomNavigationBar: AppBottomNav(
+        currentTab: AppBottomNavTab.middle,
+        role: role,
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _openDestinationEditor,
+        backgroundColor: palette.secondary,
+        foregroundColor: palette.primaryForeground,
+        icon: const Icon(Icons.add_location_alt_outlined),
+        label: const Text('Add destination'),
+      ),
+      body: SafeArea(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 430),
+            child: CustomScrollView(
+              slivers: [
+                SliverToBoxAdapter(
+                  child: AppGradientHeader(
+                    title: 'Saved Destinations',
+                    subtitle: 'Plan campus trips faster with your favorite places',
+                    onBack: () => context.pop(),
+                    height: 170,
+                  ),
+                ),
+                SliverPadding(
+                  padding: const EdgeInsets.all(AppSpacing.m),
+                  sliver: SliverMainAxisGroup(
+                    slivers: [
+                      SliverToBoxAdapter(
+                        child: _TopPanel(
+                          selectedSort: selectedSort,
+                          onSortChanged: (sort) {
+                            ref.read(savedDestinationsSortProvider.notifier).state =
+                                sort;
+                          },
+                          onQuickAddCurrentLocation: _isAddingCurrentLocation
+                              ? null
+                              : _addCurrentLocationQuickly,
+                          isAddingCurrentLocation: _isAddingCurrentLocation,
+                          lastQuickPick:
+                              bootstrapAsync.valueOrNull?.lastQuickPick,
+                        ),
+                      ),
+                      const SliverToBoxAdapter(
+                        child: SizedBox(height: AppSpacing.l),
+                      ),
+                      SliverToBoxAdapter(
+                        child: _TrendingSection(trendingAsync: trendingAsync),
+                      ),
+                      const SliverToBoxAdapter(
+                        child: SizedBox(height: AppSpacing.l),
+                      ),
+                      destinationsAsync.when(
+                        data: (destinations) {
+                          final position = bootstrapAsync.valueOrNull?.position;
+                          if (destinations.isEmpty) {
+                            return SliverToBoxAdapter(
+                              child: _EmptyState(
+                                onAddPressed: _openDestinationEditor,
+                              ),
+                            );
+                          }
+
+                          return SliverList.builder(
+                            itemCount: destinations.length,
+                            itemBuilder: (context, index) {
+                              final destination = destinations[index];
+                              return Padding(
+                                padding: const EdgeInsets.only(bottom: AppSpacing.m),
+                                child: FutureBuilder<Map<int, double>>(
+                                  future: position == null || destination.localId == null
+                                      ? Future<Map<int, double>>.value(
+                                          const <int, double>{},
+                                        )
+                                      : ref
+                                          .read(savedDestinationsRepositoryProvider)
+                                          .loadDistancesForCurrentLocation(
+                                            currentLatitude: position.latitude,
+                                            currentLongitude: position.longitude,
+                                            destinations: <SavedDestination>[
+                                              destination,
+                                            ],
+                                          ),
+                                  builder: (context, snapshot) {
+                                    final distance = destination.localId == null
+                                        ? null
+                                        : snapshot.data?[destination.localId!];
+                                    return SavedDestinationTile(
+                                      destination: destination,
+                                      distanceKm: distance,
+                                      onTap: () {
+                                        if (destination.localId == null) {
+                                          return;
+                                        }
+                                        context.push(
+                                          AppRoutes.savedDestinationDetailById(
+                                            destination.localId!,
+                                          ),
+                                        );
+                                      },
+                                      onDelete: () => _deleteDestination(destination),
+                                    );
+                                  },
+                                ),
+                              );
+                            },
+                          );
+                        },
+                        loading: () => const SliverToBoxAdapter(
+                          child: Padding(
+                            padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+                            child: Center(child: CircularProgressIndicator()),
+                          ),
+                        ),
+                        error: (error, _) => SliverToBoxAdapter(
+                          child: _ErrorState(message: error.toString()),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TrendingSection extends StatelessWidget {
+  const _TrendingSection({required this.trendingAsync});
+
+  final AsyncValue<List<SavedDestinationTrendingEntry>> trendingAsync;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        boxShadow: AppShadows.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Trending on campus',
+            style: TextStyle(
+              color: palette.textPrimary,
+              fontWeight: FontWeight.w800,
+              fontSize: 18,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            'Live BQ-M4 snapshot of the destinations students save most often.',
+            style: TextStyle(
+              color: palette.textSecondary,
+              height: 1.35,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          trendingAsync.when(
+            data: (entries) {
+              if (entries.isEmpty) {
+                return Text(
+                  'No shared destination trends are available yet.',
+                  style: TextStyle(color: palette.textSecondary),
+                );
+              }
+
+              return Column(
+                children: [
+                  for (var index = 0; index < entries.length; index++)
+                    Padding(
+                      padding: EdgeInsets.only(
+                        bottom: index == entries.length - 1 ? 0 : AppSpacing.s,
+                      ),
+                      child: _TrendingRow(
+                        rank: index + 1,
+                        entry: entries[index],
+                      ),
+                    ),
+                ],
+              );
+            },
+            loading: () => const Padding(
+              padding: EdgeInsets.symmetric(vertical: AppSpacing.s),
+              child: LinearProgressIndicator(),
+            ),
+            error: (error, stackTrace) => Text(
+              'Campus trends are temporarily unavailable.',
+              style: TextStyle(color: palette.textSecondary),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrendingRow extends StatelessWidget {
+  const _TrendingRow({
+    required this.rank,
+    required this.entry,
+  });
+
+  final int rank;
+  final SavedDestinationTrendingEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 32,
+          height: 32,
+          decoration: BoxDecoration(
+            color: palette.secondarySoft,
+            borderRadius: BorderRadius.circular(999),
+          ),
+          alignment: Alignment.center,
+          child: Text(
+            '$rank',
+            style: TextStyle(
+              color: palette.secondary,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.s),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                entry.name,
+                style: TextStyle(
+                  color: palette.textPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                entry.address,
+                style: TextStyle(
+                  color: palette.textSecondary,
+                  height: 1.3,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: AppSpacing.s),
+        Text(
+          '${entry.saveCount} saves',
+          style: TextStyle(
+            color: palette.textPrimary,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TopPanel extends StatelessWidget {
+  const _TopPanel({
+    required this.selectedSort,
+    required this.onSortChanged,
+    required this.onQuickAddCurrentLocation,
+    required this.isAddingCurrentLocation,
+    required this.lastQuickPick,
+  });
+
+  final SavedDestinationsSort selectedSort;
+  final ValueChanged<SavedDestinationsSort> onSortChanged;
+  final VoidCallback? onQuickAddCurrentLocation;
+  final bool isAddingCurrentLocation;
+  final SavedDestination? lastQuickPick;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        boxShadow: AppShadows.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Your saved places',
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 20,
+                  ),
+                ),
+              ),
+              FilledButton.tonalIcon(
+                onPressed: onQuickAddCurrentLocation,
+                icon: isAddingCurrentLocation
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.my_location),
+                label: const Text('Save current'),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Text(
+            lastQuickPick == null
+                ? 'No quick pick yet. Your most recent destination will appear here.'
+                : 'Last quick pick: ${lastQuickPick!.displayLabel}',
+            style: TextStyle(
+              color: palette.textSecondary,
+              height: 1.35,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          Wrap(
+            spacing: AppSpacing.s,
+            children: [
+              ChoiceChip(
+                label: const Text('Recent'),
+                selected: selectedSort == SavedDestinationsSort.recent,
+                onSelected: (_) => onSortChanged(SavedDestinationsSort.recent),
+              ),
+              ChoiceChip(
+                label: const Text('Most used'),
+                selected: selectedSort == SavedDestinationsSort.useCount,
+                onSelected: (_) => onSortChanged(SavedDestinationsSort.useCount),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onAddPressed});
+
+  final VoidCallback onAddPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.l),
+      decoration: BoxDecoration(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        boxShadow: AppShadows.sm,
+      ),
+      child: Column(
+        children: [
+          Icon(Icons.route_outlined, size: 64, color: palette.secondary),
+          const SizedBox(height: AppSpacing.s),
+          Text(
+            'No destinations saved yet',
+            style: TextStyle(
+              color: palette.textPrimary,
+              fontWeight: FontWeight.w800,
+              fontSize: 20,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            'Save your most frequent places to prefill trip planning with one tap.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: palette.textSecondary, height: 1.35),
+          ),
+          const SizedBox(height: AppSpacing.m),
+          FilledButton.icon(
+            onPressed: onAddPressed,
+            icon: const Icon(Icons.add_location_alt_outlined),
+            label: const Text('Add first destination'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.l),
+      decoration: BoxDecoration(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        boxShadow: AppShadows.sm,
+      ),
+      child: Column(
+        children: [
+          Icon(Icons.error_outline, size: 54, color: palette.error),
+          const SizedBox(height: AppSpacing.s),
+          Text(
+            'We could not load your saved destinations',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: palette.textPrimary,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: palette.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SavedDestinationDraft {
+  const _SavedDestinationDraft({
+    required this.name,
+    required this.address,
+    required this.thumbnailUrl,
+  });
+
+  final String name;
+  final String address;
+  final String thumbnailUrl;
+}
+
+class _SavedDestinationEditorSheet extends StatefulWidget {
+  const _SavedDestinationEditorSheet({this.existing});
+
+  final SavedDestination? existing;
+
+  @override
+  State<_SavedDestinationEditorSheet> createState() =>
+      _SavedDestinationEditorSheetState();
+}
+
+class _SavedDestinationEditorSheetState
+    extends State<_SavedDestinationEditorSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _addressController;
+  late final TextEditingController _thumbnailController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.existing?.name ?? '');
+    _addressController = TextEditingController(
+      text: widget.existing?.address ?? '',
+    );
+    _thumbnailController = TextEditingController(
+      text: widget.existing?.thumbnailUrl ?? '',
+    );
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _addressController.dispose();
+    _thumbnailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final insets = MediaQuery.of(context).viewInsets.bottom;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        AppSpacing.m,
+        AppSpacing.xl,
+        AppSpacing.m,
+        insets + AppSpacing.m,
+      ),
+      child: Material(
+        color: palette.card,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.l),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  widget.existing == null
+                      ? 'Add saved destination'
+                      : 'Edit destination',
+                  style: TextStyle(
+                    color: palette.textPrimary,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 20,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.m),
+                TextFormField(
+                  controller: _nameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Label',
+                    hintText: 'Home, Library, Main Gate...',
+                  ),
+                  validator: (value) => value == null || value.trim().isEmpty
+                      ? 'Enter a short label.'
+                      : null,
+                ),
+                const SizedBox(height: AppSpacing.m),
+                TextFormField(
+                  controller: _addressController,
+                  decoration: const InputDecoration(
+                    labelText: 'Address',
+                    hintText: 'Enter an address or campus place',
+                  ),
+                  validator: (value) => value == null || value.trim().isEmpty
+                      ? 'Enter an address.'
+                      : null,
+                ),
+                const SizedBox(height: AppSpacing.m),
+                TextFormField(
+                  controller: _thumbnailController,
+                  decoration: const InputDecoration(
+                    labelText: 'Thumbnail URL (optional)',
+                    hintText: 'https://...',
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.l),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('Cancel'),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.s),
+                    Expanded(
+                      child: FilledButton(
+                        onPressed: () {
+                          if (!(_formKey.currentState?.validate() ?? false)) {
+                            return;
+                          }
+                          Navigator.of(context).pop(
+                            _SavedDestinationDraft(
+                              name: _nameController.text,
+                              address: _addressController.text,
+                              thumbnailUrl: _thumbnailController.text,
+                            ),
+                          );
+                        },
+                        child: const Text('Save'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/wheels/lib/features/saved_destinations/presentation/widgets/saved_destination_tile.dart
+++ b/wheels/lib/features/saved_destinations/presentation/widgets/saved_destination_tile.dart
@@ -1,0 +1,210 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../theme/app_radius.dart';
+import '../../../../theme/app_shadows.dart';
+import '../../../../theme/app_spacing.dart';
+import '../../../../theme/app_theme_palette.dart';
+import '../../domain/entities/saved_destination.dart';
+
+class SavedDestinationTile extends StatelessWidget {
+  const SavedDestinationTile({
+    super.key,
+    required this.destination,
+    required this.onTap,
+    this.distanceKm,
+    this.onDelete,
+  });
+
+  final SavedDestination destination;
+  final VoidCallback onTap;
+  final VoidCallback? onDelete;
+  final double? distanceKm;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final subtitle = destination.address.trim() == destination.displayLabel
+        ? destination.coordinatesLabel
+        : destination.address;
+
+    return Dismissible(
+      key: ValueKey('saved-destination-${destination.localId}'),
+      direction: onDelete == null ? DismissDirection.none : DismissDirection.endToStart,
+      onDismissed: (_) => onDelete?.call(),
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.l),
+        decoration: BoxDecoration(
+          color: palette.error,
+          borderRadius: BorderRadius.circular(AppRadius.md),
+        ),
+        child: const Icon(Icons.delete_outline, color: Colors.white),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          child: Container(
+            padding: const EdgeInsets.all(AppSpacing.m),
+            decoration: BoxDecoration(
+              color: palette.card,
+              borderRadius: BorderRadius.circular(AppRadius.md),
+              boxShadow: AppShadows.sm,
+            ),
+            child: Row(
+              children: [
+                _Thumbnail(
+                  destination: destination,
+                ),
+                const SizedBox(width: AppSpacing.m),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              destination.displayLabel,
+                              style: TextStyle(
+                                color: palette.textPrimary,
+                                fontWeight: FontWeight.w700,
+                                fontSize: 16,
+                              ),
+                            ),
+                          ),
+                          if (destination.pendingSync)
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: AppSpacing.s,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: palette.secondary.withValues(alpha: 0.12),
+                                borderRadius: BorderRadius.circular(999),
+                              ),
+                              child: Text(
+                                'Pending sync',
+                                style: TextStyle(
+                                  color: palette.secondary,
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        subtitle,
+                        style: TextStyle(
+                          color: palette.textSecondary,
+                          height: 1.35,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.s),
+                      Wrap(
+                        spacing: AppSpacing.s,
+                        runSpacing: AppSpacing.xs,
+                        children: [
+                          _MetaPill(
+                            label: '${destination.useCount} uses',
+                          ),
+                          if (distanceKm != null)
+                            _MetaPill(
+                              label: '${distanceKm!.toStringAsFixed(1)} km away',
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.s),
+                Icon(Icons.chevron_right, color: palette.textSecondary),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Thumbnail extends StatelessWidget {
+  const _Thumbnail({required this.destination});
+
+  final SavedDestination destination;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final thumbnailUrl = destination.thumbnailUrl;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppRadius.sm),
+      child: SizedBox(
+        width: 68,
+        height: 68,
+        child: thumbnailUrl == null || thumbnailUrl.trim().isEmpty
+            ? Container(
+                color: palette.secondarySoft,
+                child: Icon(
+                  Icons.place_outlined,
+                  color: palette.secondary,
+                  size: 28,
+                ),
+              )
+            : CachedNetworkImage(
+                imageUrl: thumbnailUrl,
+                fit: BoxFit.cover,
+                memCacheWidth: 136,
+                memCacheHeight: 136,
+                placeholder: (context, imageUrl) => Container(
+                  color: palette.secondarySoft,
+                  child: Icon(
+                    Icons.photo_outlined,
+                    color: palette.secondary,
+                  ),
+                ),
+                errorWidget: (context, imageUrl, error) => Container(
+                  color: palette.secondarySoft,
+                  child: Icon(
+                    Icons.broken_image_outlined,
+                    color: palette.secondary,
+                  ),
+                ),
+              ),
+      ),
+    );
+  }
+}
+
+class _MetaPill extends StatelessWidget {
+  const _MetaPill({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s,
+        vertical: 6,
+      ),
+      decoration: BoxDecoration(
+        color: palette.input,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: palette.textSecondary,
+          fontWeight: FontWeight.w600,
+          fontSize: 12,
+        ),
+      ),
+    );
+  }
+}

--- a/wheels/lib/features/saved_destinations/presentation/widgets/saved_destination_tile.dart
+++ b/wheels/lib/features/saved_destinations/presentation/widgets/saved_destination_tile.dart
@@ -14,11 +14,13 @@ class SavedDestinationTile extends StatelessWidget {
     required this.onTap,
     this.distanceKm,
     this.onDelete,
+    this.onEdit,
   });
 
   final SavedDestination destination;
   final VoidCallback onTap;
   final VoidCallback? onDelete;
+  final VoidCallback? onEdit;
   final double? distanceKm;
 
   @override
@@ -122,7 +124,17 @@ class SavedDestinationTile extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: AppSpacing.s),
-                Icon(Icons.chevron_right, color: palette.textSecondary),
+                Column(
+                  children: [
+                    if (onEdit != null)
+                      IconButton(
+                        tooltip: 'Edit destination',
+                        onPressed: onEdit,
+                        icon: Icon(Icons.edit_outlined, color: palette.primary),
+                      ),
+                    Icon(Icons.chevron_right, color: palette.textSecondary),
+                  ],
+                ),
               ],
             ),
           ),

--- a/wheels/lib/features/saved_destinations/presentation/widgets/saved_destinations_chip.dart
+++ b/wheels/lib/features/saved_destinations/presentation/widgets/saved_destinations_chip.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../../../theme/app_spacing.dart';
+import '../../../../theme/app_theme_palette.dart';
+import '../../domain/entities/saved_destination.dart';
+
+class SavedDestinationsChip extends StatelessWidget {
+  const SavedDestinationsChip({
+    super.key,
+    required this.destination,
+    required this.onTap,
+  });
+
+  final SavedDestination destination;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return ActionChip(
+      onPressed: onTap,
+      avatar: Icon(
+        Icons.push_pin_outlined,
+        size: 16,
+        color: palette.secondary,
+      ),
+      backgroundColor: palette.secondarySoft,
+      side: BorderSide(color: palette.border),
+      label: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+        child: Text(
+          destination.displayLabel,
+          style: TextStyle(
+            color: palette.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/wheels/lib/router/app_router.dart
+++ b/wheels/lib/router/app_router.dart
@@ -116,11 +116,23 @@ class AppRouter {
       ),
       GoRoute(
         path: AppRoutes.createRide,
-        builder: (context, state) => const CreateRideScreen(),
+        builder: (context, state) => CreateRideScreen(
+          initialSavedDestinationId: int.tryParse(
+            state.uri.queryParameters['savedDestinationId'] ?? '',
+          ),
+          forceSavedDestination:
+              state.uri.queryParameters['forceSavedDestination'] == '1',
+        ),
       ),
       GoRoute(
         path: AppRoutes.rides,
-        builder: (context, state) => const RidesSearchScreen(),
+        builder: (context, state) => RidesSearchScreen(
+          initialSavedDestinationId: int.tryParse(
+            state.uri.queryParameters['savedDestinationId'] ?? '',
+          ),
+          forceSavedDestination:
+              state.uri.queryParameters['forceSavedDestination'] == '1',
+        ),
       ),
       GoRoute(
         path: AppRoutes.rideDetails,

--- a/wheels/lib/router/app_router.dart
+++ b/wheels/lib/router/app_router.dart
@@ -23,6 +23,8 @@ import '../features/rides/presentation/screens/create_ride_screen.dart';
 import '../features/rides/presentation/screens/group_screen.dart';
 import '../features/rides/presentation/screens/ride_details_screen.dart';
 import '../features/rides/presentation/screens/rides_search_screen.dart';
+import '../features/saved_destinations/presentation/screens/saved_destination_detail_screen.dart';
+import '../features/saved_destinations/presentation/screens/saved_destinations_screen.dart';
 import '../features/trust/presentation/screens/trust_screen.dart';
 import '../features/wallet/presentation/screens/wallet_screen.dart';
 import '../features/wallet/presentation/screens/withdrawal_request_screen.dart';
@@ -183,6 +185,20 @@ class AppRouter {
         path: AppRoutes.helpArticle,
         builder: (context, state) => HelpArticleScreen(
           articleId: state.pathParameters['articleId'] ?? 'unknown',
+        ),
+      ),
+      GoRoute(
+        path: AppRoutes.savedDestinations,
+        builder: (context, state) => const SavedDestinationsScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.savedDestinationDetail,
+        builder: (context, state) => SavedDestinationDetailScreen(
+          localId:
+              int.tryParse(
+                state.pathParameters['savedDestinationId'] ?? '',
+              ) ??
+              -1,
         ),
       ),
     ],

--- a/wheels/lib/router/app_routes.dart
+++ b/wheels/lib/router/app_routes.dart
@@ -34,4 +34,8 @@ class AppRoutes {
       '/help/article/$articleId';
   static String savedDestinationDetailById(int savedDestinationId) =>
       '/saved-destinations/$savedDestinationId';
+  static String ridesWithSavedDestination(int savedDestinationId) =>
+      '/rides?savedDestinationId=$savedDestinationId&forceSavedDestination=1';
+  static String createRideWithSavedDestination(int savedDestinationId) =>
+      '/create-ride?savedDestinationId=$savedDestinationId&forceSavedDestination=1';
 }

--- a/wheels/lib/router/app_routes.dart
+++ b/wheels/lib/router/app_routes.dart
@@ -20,6 +20,9 @@ class AppRoutes {
   static const rideHistory = '/ride-history';
   static const helpCenter = '/help';
   static const helpArticle = '/help/article/:articleId';
+  static const savedDestinations = '/saved-destinations';
+  static const savedDestinationDetail =
+      '/saved-destinations/:savedDestinationId';
 
   static String groupByRideId(String rideId) => '/group/$rideId';
   static String groupChatByTripId(String tripId) =>
@@ -29,4 +32,6 @@ class AppRoutes {
   static String paymentByRideId(String rideId) => '/payment?rideId=$rideId';
   static String helpArticleById(String articleId) =>
       '/help/article/$articleId';
+  static String savedDestinationDetailById(int savedDestinationId) =>
+      '/saved-destinations/$savedDestinationId';
 }


### PR DESCRIPTION
## Summary

This PR implements the Sprint 4 Flutter feature **Saved Destinations & Trip Planner**.

The feature adds a persistent, user-managed collection of saved destinations that can be reused across sessions and integrated directly into trip planning flows. It includes two new views, offline-first local persistence, deferred synchronization, reactive updates, distance caching, and quick-pick integration with ride search and ride creation.

## What was added

### New feature
- `Saved Destinations & Trip Planner`

### New views
- `SavedDestinationsScreen`
- `SavedDestinationDetailScreen`

### New capabilities
- create, edit, delete, and browse saved destinations
- quick-save current location
- quick-pick chips for frequent destination reuse
- destination detail view with local usage stats
- direct handoff into:
  - `RidesSearchScreen`
  - `CreateRideScreen`

## Architecture and implementation

### Local storage
- added SQLite-backed local persistence for `saved_destinations`
- added `SharedPreferences` support for:
  - last selected quick-pick destination

### Reactive data flow
- exposed saved destinations through a local `Stream`
- added Riverpod providers for:
  - repository access
  - current user destination stream
  - bootstrap state
  - quick-pick state
  - trending destinations

### Caching
- implemented in-memory distance cache using a capped `LinkedHashMap`
- kept thumbnail rendering compatible with `cached_network_image`

### Multi-threading / async work
- added isolate-based batch distance calculation
- used `Future.wait` during bootstrap flows
- used `compute()` for sync batch serialization

### Eventual connectivity
- offline-first writes now persist locally with `pending_sync`
- added deferred sync worker that flushes destinations to Firestore on reconnect
- reads remain local-first for continuity when offline

## Integration points

### Router
- added routes for:
  - saved destinations list
  - saved destination detail

### Ride planning integration
- integrated saved-destination quick-picks into:
  - `RidesSearchScreen`
  - `CreateRideScreen`
- added route-based saved-destination prefill support so “use this destination” actions reliably override previous draft/cache state

## BQ-M4 support
- added a visible **“Trending on campus”** section in `SavedDestinationsScreen`
- this section reads aggregate saved-destination activity from Firestore collection-group data and surfaces a live in-app view aligned with **BQ-M4**

## Additional fixes included
- enabled editing from the saved destinations list UI
- made manual destination creation resilient when address geocoding is unavailable by preserving local saves even if coordinates cannot be resolved immediately
- prevented distance calculations from running on destinations that still have unresolved coordinates

## Notes
- this branch does **not** include the `RidesSearchScreen` micro-optimization branch yet
- a later merge with that branch will likely require **manual conflict resolution** in `rides_search_screen.dart`, since both branches modify `build()` and `_buildResultsSection()`
- the feature logic is compatible with the micro-optimization, but both changes should be preserved during merge resolution